### PR TITLE
fix(release): allow cold Run image startup

### DIFF
--- a/control/controld/README.md
+++ b/control/controld/README.md
@@ -67,8 +67,11 @@ preserving a hard process limit and protecting each axnoded independently.
 
 Periodic rollout, run, node, Service, tunnel, and Function maintenance runs in
 independent component loops. A slow dependency in one component therefore does
-not block the cadence of unrelated controllers. Each loop is non-overlapping,
-inherits the process lifecycle context, and has a bounded execution timeout.
+not block the cadence of unrelated controllers. Each loop is non-overlapping
+and inherits the process lifecycle context. Short maintenance loops have a
+bounded component timeout. Run and Service allocation creation instead use a
+bounded timeout per lifecycle item so cold image materialization cannot consume
+the budget of later work or be canceled by a shorter maintenance deadline.
 Service autoscaling and the lower-frequency recovery sweep share one serialized
 Service maintenance loop, while service-ID event workers retain their bounded
 cross-service concurrency. On shutdown, active calls are canceled before the

--- a/control/controld/internal/app/reconciler.go
+++ b/control/controld/internal/app/reconciler.go
@@ -64,7 +64,7 @@ func (a *App) startFunctionInvocationWorkers() {
 
 func (a *App) startPeriodicReconciler() {
 	a.startPeriodicComponent(reconcilekernel.ComponentRollout, a.rolloutPG != nil, a.reconcileRolloutMaintenance)
-	a.startPeriodicComponent(reconcilekernel.ComponentRun, a.runReconciler != nil, func(ctx context.Context, now time.Time) error {
+	a.startPeriodicLifecycleComponent(reconcilekernel.ComponentRun, a.runReconciler != nil, func(ctx context.Context, now time.Time) error {
 		return a.runReconciler.ReconcilePending(ctx, now)
 	})
 	a.startPeriodicComponent(reconcilekernel.ComponentNode, a.nodeReconciler != nil, func(ctx context.Context, now time.Time) error {
@@ -78,6 +78,16 @@ func (a *App) startPeriodicReconciler() {
 }
 
 func (a *App) startPeriodicComponent(component string, enabled bool, reconcile func(context.Context, time.Time) error) {
+	a.startPeriodicComponentLoop(component, enabled, reconcile, a.reconcileComponent)
+}
+
+func (a *App) startPeriodicLifecycleComponent(component string, enabled bool, reconcile func(context.Context, time.Time) error) {
+	a.startPeriodicComponentLoop(component, enabled, reconcile, func(component string, now time.Time, reconcile func(context.Context, time.Time) error) error {
+		return a.reconcileComponentWithContext(a.backgroundReconcileContext(), component, now, reconcile)
+	})
+}
+
+func (a *App) startPeriodicComponentLoop(component string, enabled bool, reconcile func(context.Context, time.Time) error, run func(string, time.Time, func(context.Context, time.Time) error) error) {
 	if !enabled || reconcile == nil {
 		return
 	}
@@ -90,7 +100,7 @@ func (a *App) startPeriodicComponent(component string, enabled bool, reconcile f
 		for {
 			select {
 			case <-ticker.C:
-				a.reconcileComponent(component, a.now(), reconcile)
+				run(component, a.now(), reconcile)
 			case <-lifecycleDone:
 				return
 			case <-a.stopCh:
@@ -198,7 +208,7 @@ func (a *App) startAllocationReconciler() {
 func (a *App) reconcileAllocationBatches(now time.Time) {
 	for {
 		processed := 0
-		err := a.reconcileComponent(reconcilekernel.ComponentAllocation, now, func(ctx context.Context, _ time.Time) error {
+		err := a.reconcileComponentWithContext(a.backgroundReconcileContext(), reconcilekernel.ComponentAllocation, now, func(ctx context.Context, _ time.Time) error {
 			var err error
 			processed, err = a.allocationReconciler.ReconcileAllocationBatch(ctx, a.now())
 			return err
@@ -365,16 +375,20 @@ func (a *App) notifyAllocationReconcile() {
 }
 
 func (a *App) reconcileComponent(component string, now time.Time, reconcile func(context.Context, time.Time) error) error {
+	ctx, cancel := context.WithTimeout(a.backgroundReconcileContext(), a.backgroundReconcileTimeout())
+	defer cancel()
+	return a.reconcileComponentWithContext(ctx, component, now, reconcile)
+}
+
+func (a *App) reconcileComponentWithContext(ctx context.Context, component string, now time.Time, reconcile func(context.Context, time.Time) error) error {
 	var run reconcilekernel.RunHandle
 	if a.reconcileHealth != nil {
 		run = a.reconcileHealth.RecordStart(component, now)
 	}
-	ctx, cancel := context.WithTimeout(a.backgroundReconcileContext(), a.backgroundReconcileTimeout())
 	err := reconcile(ctx, now)
 	if err == nil && ctx.Err() != nil {
 		err = ctx.Err()
 	}
-	cancel()
 	finishedAt := a.now()
 	if a.reconcileHealth != nil {
 		a.reconcileHealth.RecordResult(run, err, finishedAt)

--- a/control/controld/internal/app/reconciler_event_test.go
+++ b/control/controld/internal/app/reconciler_event_test.go
@@ -181,6 +181,46 @@ func TestPeriodicReconcileComponentsAreIsolated(t *testing.T) {
 	}
 }
 
+func TestPeriodicRunReconcileUsesItsOwnLifecycleDeadline(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	app := &App{
+		reconcileInterval: time.Millisecond,
+		reconcileTimeout:  10 * time.Millisecond,
+		now:               func() time.Time { return time.Now().UTC() },
+		reconcileCtx:      ctx,
+		cancelReconcile:   cancel,
+		stopCh:            make(chan struct{}),
+		runReconciler: runReconcilerFunc(func(ctx context.Context, _ time.Time) error {
+			select {
+			case <-time.After(30 * time.Millisecond):
+				select {
+				case result <- nil:
+				default:
+				}
+				return nil
+			case <-ctx.Done():
+				select {
+				case result <- ctx.Err():
+				default:
+				}
+				return ctx.Err()
+			}
+		}),
+		reconcileHealth: reconcilekernel.NewHealthTracker(reconcilekernel.ComponentRun),
+	}
+	app.startPeriodicReconciler()
+	t.Cleanup(func() { _ = app.Close() })
+	select {
+	case err := <-result:
+		if err != nil {
+			t.Fatalf("run reconcile was canceled by generic component timeout: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("run reconcile did not complete")
+	}
+}
+
 func TestPeriodicReconcileStopsWhenLifecycleIsCanceled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	called := make(chan struct{}, 1)
@@ -254,6 +294,77 @@ func TestReconcileComponentTimeoutIsRecordedAndCloseCancelsWork(t *testing.T) {
 	}
 }
 
+func TestAllocationReconcileIsNotBoundByGenericComponentTimeout(t *testing.T) {
+	release := make(chan struct{})
+	done := make(chan struct{})
+	app := &App{
+		reconcileTimeout: 10 * time.Millisecond,
+		now:              func() time.Time { return time.Now().UTC() },
+		allocationReconciler: allocationReconcilerFunc(func(context.Context, time.Time) (int, error) {
+			close(done)
+			<-release
+			return 0, nil
+		}),
+		reconcileHealth: reconcilekernel.NewHealthTracker(reconcilekernel.ComponentAllocation),
+	}
+	finished := make(chan struct{})
+	go func() {
+		app.reconcileAllocationBatches(app.now())
+		close(finished)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("allocation reconcile did not start")
+	}
+	select {
+	case <-finished:
+		t.Fatal("allocation reconcile was canceled by the generic component timeout")
+	case <-time.After(30 * time.Millisecond):
+	}
+	close(release)
+	select {
+	case <-finished:
+	case <-time.After(time.Second):
+		t.Fatal("allocation reconcile did not finish after release")
+	}
+	got := app.reconcileHealth.Snapshot().Components[0]
+	if got.Running || got.ConsecutiveFailures != 0 {
+		t.Fatalf("health = %#v, want completed allocation reconcile", got)
+	}
+}
+
+func TestAllocationReconcileInheritsApplicationLifecycleCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	started := make(chan struct{})
+	app := &App{
+		now:          func() time.Time { return time.Now().UTC() },
+		reconcileCtx: ctx,
+		allocationReconciler: allocationReconcilerFunc(func(ctx context.Context, _ time.Time) (int, error) {
+			close(started)
+			<-ctx.Done()
+			return 0, ctx.Err()
+		}),
+		reconcileHealth: reconcilekernel.NewHealthTracker(reconcilekernel.ComponentAllocation),
+	}
+	finished := make(chan struct{})
+	go func() {
+		app.reconcileAllocationBatches(app.now())
+		close(finished)
+	}()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("allocation reconcile did not start")
+	}
+	cancel()
+	select {
+	case <-finished:
+	case <-time.After(time.Second):
+		t.Fatal("allocation reconcile did not stop after application cancellation")
+	}
+}
+
 type reconcileFunc struct {
 	reconcilePending    func(context.Context, time.Time) error
 	reconcileAutoscaled func(context.Context, time.Time) error
@@ -269,6 +380,12 @@ func (f runReconcilerFunc) ReconcilePending(ctx context.Context, now time.Time) 
 type availabilityReconcilerFunc func(context.Context, time.Time) error
 
 func (f availabilityReconcilerFunc) ReconcileUnavailableNodes(ctx context.Context, now time.Time) error {
+	return f(ctx, now)
+}
+
+type allocationReconcilerFunc func(context.Context, time.Time) (int, error)
+
+func (f allocationReconcilerFunc) ReconcileAllocationBatch(ctx context.Context, now time.Time) (int, error) {
 	return f(ctx, now)
 }
 

--- a/control/controld/internal/application/run/reconciler.go
+++ b/control/controld/internal/application/run/reconciler.go
@@ -28,12 +28,20 @@ func (r reconciler) ReconcilePending(ctx context.Context, now time.Time) error {
 	if r.store == nil || r.lifecycle == nil {
 		return nil
 	}
-	items, err := r.store.DueReconcileItems(ctx, allocationkernel.DefaultReconcileLimit, now)
+	queryCtx, cancel := context.WithTimeout(ctx, allocationkernel.LifecycleOperationTimeout)
+	items, err := r.store.DueReconcileItems(queryCtx, allocationkernel.DefaultReconcileLimit, now)
+	cancel()
 	if err != nil {
 		return err
 	}
 	for _, item := range items {
-		err = errors.Join(err, r.reconcileAllocation(ctx, item, now))
+		timeout := allocationkernel.LifecycleOperationTimeout
+		if item.Reason == allocationkernel.ReconcileReasonCreate {
+			timeout = allocationkernel.CreateExecutionTimeout
+		}
+		itemCtx, cancel := context.WithTimeout(ctx, timeout)
+		err = errors.Join(err, r.reconcileAllocation(itemCtx, item, now))
+		cancel()
 	}
 	return err
 }

--- a/control/controld/internal/application/run/reconciler_test.go
+++ b/control/controld/internal/application/run/reconciler_test.go
@@ -3,10 +3,10 @@ package apprun
 import (
 	"context"
 	"errors"
-	allocationkernel "github.com/cofy-x/axern/control/controld/internal/kernel/allocation"
 	"testing"
 	"time"
 
+	allocationkernel "github.com/cofy-x/axern/control/controld/internal/kernel/allocation"
 	runkernel "github.com/cofy-x/axern/control/controld/internal/kernel/run"
 	environmentv1 "github.com/cofy-x/axern/sdk/go/gen/axern/control/environment/v1"
 	runv1 "github.com/cofy-x/axern/sdk/go/gen/axern/control/run/v1"
@@ -117,6 +117,13 @@ func TestReconcilerStartsQueuedAllocation(t *testing.T) {
 	}
 	if lifecycle.created != 1 {
 		t.Fatalf("create calls = %d, want 1", lifecycle.created)
+	}
+	if !lifecycle.createHasDeadline {
+		t.Fatal("create context has no deadline")
+	}
+	remaining := time.Until(lifecycle.createDeadline)
+	if remaining < 9*time.Minute || remaining > allocationkernel.CreateExecutionTimeout {
+		t.Fatalf("create deadline remaining = %s, want approximately %s", remaining, allocationkernel.CreateExecutionTimeout)
 	}
 	if store.completedStartAllocationID != "alloc-a" {
 		t.Fatalf("completed start allocation = %q, want alloc-a", store.completedStartAllocationID)
@@ -269,14 +276,17 @@ func (f *fakeReconcileStore) recordSchedule(req allocationkernel.ScheduleReconci
 }
 
 type fakeReconcileLifecycle struct {
-	deleted   int
-	created   int
-	deleteErr error
-	createErr error
+	deleted           int
+	created           int
+	deleteErr         error
+	createErr         error
+	createDeadline    time.Time
+	createHasDeadline bool
 }
 
-func (f *fakeReconcileLifecycle) CreateAllocation(context.Context, string, *runv1.Run, *environmentv1.Environment, string) error {
+func (f *fakeReconcileLifecycle) CreateAllocation(ctx context.Context, _ string, _ *runv1.Run, _ *environmentv1.Environment, _ string) error {
 	f.created++
+	f.createDeadline, f.createHasDeadline = ctx.Deadline()
 	return f.createErr
 }
 

--- a/control/controld/internal/application/service/controller_allocation_reconcile.go
+++ b/control/controld/internal/application/service/controller_allocation_reconcile.go
@@ -15,10 +15,9 @@ import (
 )
 
 const (
-	allocationReconcileLeaseTTL         = 30 * time.Second
-	allocationReconcileRenewInterval    = 10 * time.Second
-	allocationReconcileExecutionTimeout = 10 * time.Minute
-	allocationReconcileRefillInterval   = 10 * time.Millisecond
+	allocationReconcileLeaseTTL       = 30 * time.Second
+	allocationReconcileRenewInterval  = 10 * time.Second
+	allocationReconcileRefillInterval = 10 * time.Millisecond
 )
 
 type allocationReconcileResult struct {
@@ -138,7 +137,11 @@ func nonnegativeDuration(duration time.Duration) time.Duration {
 }
 
 func (c *controller) startAllocationReconcileClaim(ctx context.Context, item allocationkernel.ReconcileItem, claimedAt time.Time) *allocationReconcileClaim {
-	workerCtx, cancel := context.WithTimeout(ctx, allocationReconcileExecutionTimeout)
+	timeout := allocationkernel.LifecycleOperationTimeout
+	if item.Reason == allocationkernel.ReconcileReasonCreate {
+		timeout = allocationkernel.CreateExecutionTimeout
+	}
+	workerCtx, cancel := context.WithTimeout(ctx, timeout)
 	claim := &allocationReconcileClaim{
 		item:        item,
 		claimedAt:   claimedAt,

--- a/control/controld/internal/kernel/allocation/reconcile.go
+++ b/control/controld/internal/kernel/allocation/reconcile.go
@@ -3,13 +3,15 @@ package allocationkernel
 import "time"
 
 const (
-	ReconcileReasonCreate   = "create"
-	ReconcileReasonDelete   = "delete"
-	DefaultReconcileLimit   = 20
-	DeleteRetryDelay        = 5 * time.Second
-	CreateRetryInitialDelay = 2 * time.Second
-	CreateRetryMaxDelay     = 30 * time.Second
-	CreateRetryMaxAttempts  = 5
+	ReconcileReasonCreate     = "create"
+	ReconcileReasonDelete     = "delete"
+	DefaultReconcileLimit     = 20
+	DeleteRetryDelay          = 5 * time.Second
+	CreateRetryInitialDelay   = 2 * time.Second
+	CreateRetryMaxDelay       = 30 * time.Second
+	CreateRetryMaxAttempts    = 5
+	CreateExecutionTimeout    = 10 * time.Minute
+	LifecycleOperationTimeout = 60 * time.Second
 )
 
 type ReconcileItem struct {

--- a/control/controld/internal/nodebridge/lifecycle.go
+++ b/control/controld/internal/nodebridge/lifecycle.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	allocationkernel "github.com/cofy-x/axern/control/controld/internal/kernel/allocation"
 	environmentkernel "github.com/cofy-x/axern/control/controld/internal/kernel/environment"
 	secretkernel "github.com/cofy-x/axern/control/controld/internal/kernel/secret"
 	servicekernel "github.com/cofy-x/axern/control/controld/internal/kernel/service"
@@ -21,7 +22,6 @@ import (
 
 const (
 	DefaultRuntime = "runsc"
-	DefaultTimeout = 60 * time.Second
 )
 
 const (
@@ -36,12 +36,14 @@ type Bridge struct {
 	secretValues        secretkernel.ValueResolver
 	registryCredentials environmentkernel.RegistryCredentialResolver
 	defaultRuntime      string
-	timeout             time.Duration
+	createTimeout       time.Duration
+	operationTimeout    time.Duration
 }
 
 type Config struct {
 	DefaultRuntime      string
-	Timeout             time.Duration
+	CreateTimeout       time.Duration
+	OperationTimeout    time.Duration
 	SecretValues        secretkernel.ValueResolver
 	RegistryCredentials environmentkernel.RegistryCredentialResolver
 }
@@ -50,20 +52,24 @@ func New(client LifecycleClient, cfg Config) *Bridge {
 	if cfg.DefaultRuntime == "" {
 		cfg.DefaultRuntime = DefaultRuntime
 	}
-	if cfg.Timeout <= 0 {
-		cfg.Timeout = DefaultTimeout
+	if cfg.CreateTimeout <= 0 {
+		cfg.CreateTimeout = allocationkernel.CreateExecutionTimeout
+	}
+	if cfg.OperationTimeout <= 0 {
+		cfg.OperationTimeout = allocationkernel.LifecycleOperationTimeout
 	}
 	return &Bridge{
 		client:              client,
 		secretValues:        cfg.SecretValues,
 		registryCredentials: cfg.RegistryCredentials,
 		defaultRuntime:      cfg.DefaultRuntime,
-		timeout:             cfg.Timeout,
+		createTimeout:       cfg.CreateTimeout,
+		operationTimeout:    cfg.OperationTimeout,
 	}
 }
 
 func (b *Bridge) CreateAllocation(ctx context.Context, target string, run *runv1.Run, env *environmentv1.Environment, nodeID string) error {
-	callCtx, cancel := context.WithTimeout(ctx, b.timeout)
+	callCtx, cancel := context.WithTimeout(ctx, b.createTimeout)
 	defer cancel()
 	stageStarted := time.Now()
 	req, err := b.buildCreateAllocationRequest(callCtx, createAllocationRequestParams{
@@ -88,7 +94,7 @@ func (b *Bridge) CreateAllocation(ctx context.Context, target string, run *runv1
 }
 
 func (b *Bridge) CreateResolvedAllocation(ctx context.Context, req servicekernel.CreateResolvedAllocationRequest) (*servicekernel.CreateResolvedAllocationResult, error) {
-	callCtx, cancel := context.WithTimeout(ctx, b.timeout)
+	callCtx, cancel := context.WithTimeout(ctx, b.createTimeout)
 	defer cancel()
 	stageStarted := time.Now()
 	wireReq, err := b.buildCreateAllocationRequest(callCtx, createAllocationRequestParams{
@@ -127,7 +133,7 @@ func (b *Bridge) DeleteAllocation(ctx context.Context, target, allocationID stri
 }
 
 func (b *Bridge) DeleteResolvedAllocation(ctx context.Context, target, allocationID string, attempt int64, nodeID string) ([]*privatestoragev1.VolumeReleaseObservation, error) {
-	callCtx, cancel := context.WithTimeout(ctx, b.timeout)
+	callCtx, cancel := context.WithTimeout(ctx, b.operationTimeout)
 	defer cancel()
 	resp, err := b.client.DeleteAllocation(callCtx, target, &privatenodev1.DeleteAllocationRequest{
 		AllocationID:   allocationID,
@@ -145,7 +151,7 @@ func (b *Bridge) DeleteResolvedAllocation(ctx context.Context, target, allocatio
 }
 
 func (b *Bridge) AllocationDeleted(ctx context.Context, target, allocationID string, attempt int64, nodeID string) (bool, error) {
-	callCtx, cancel := context.WithTimeout(ctx, b.timeout)
+	callCtx, cancel := context.WithTimeout(ctx, b.operationTimeout)
 	defer cancel()
 	_, err := b.client.GetAllocationStatus(callCtx, target, &privatenodev1.GetAllocationStatusRequest{
 		AllocationID: allocationID,
@@ -162,7 +168,7 @@ func (b *Bridge) AllocationDeleted(ctx context.Context, target, allocationID str
 }
 
 func (b *Bridge) DeleteVolume(ctx context.Context, target string, reclaim *privatestoragev1.VolumeReclaim) error {
-	callCtx, cancel := context.WithTimeout(ctx, b.timeout)
+	callCtx, cancel := context.WithTimeout(ctx, b.operationTimeout)
 	defer cancel()
 	_, err := b.client.DeleteVolume(callCtx, target, &privatenodev1.DeleteVolumeRequest{
 		ClaimID: reclaim.GetClaimID(), Backend: reclaim.GetBackend(), BackendHandle: reclaim.GetBackendHandle(), NodeID: reclaim.GetNodeID(),

--- a/control/controld/internal/nodebridge/lifecycle_test.go
+++ b/control/controld/internal/nodebridge/lifecycle_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	allocationkernel "github.com/cofy-x/axern/control/controld/internal/kernel/allocation"
 	secretkernel "github.com/cofy-x/axern/control/controld/internal/kernel/secret"
 	servicekernel "github.com/cofy-x/axern/control/controld/internal/kernel/service"
 	catalogv1 "github.com/cofy-x/axern/sdk/go/gen/axern/control/catalog/v1"
@@ -22,6 +23,24 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/durationpb"
 )
+
+func TestBridgeUsesSeparateLifecycleTimeouts(t *testing.T) {
+	bridge := New(&captureLifecycleClient{}, Config{})
+	if bridge.createTimeout != allocationkernel.CreateExecutionTimeout {
+		t.Fatalf("create timeout = %s, want %s", bridge.createTimeout, allocationkernel.CreateExecutionTimeout)
+	}
+	if bridge.operationTimeout != allocationkernel.LifecycleOperationTimeout {
+		t.Fatalf("operation timeout = %s, want %s", bridge.operationTimeout, allocationkernel.LifecycleOperationTimeout)
+	}
+
+	bridge = New(&captureLifecycleClient{}, Config{
+		CreateTimeout:    3 * time.Minute,
+		OperationTimeout: 15 * time.Second,
+	})
+	if bridge.createTimeout != 3*time.Minute || bridge.operationTimeout != 15*time.Second {
+		t.Fatalf("configured timeouts = create:%s operation:%s", bridge.createTimeout, bridge.operationTimeout)
+	}
+}
 
 func TestBuildCreateAllocationRequest(t *testing.T) {
 	run := &runv1.Run{

--- a/scripts/release/local-release-smoke.sh
+++ b/scripts/release/local-release-smoke.sh
@@ -7,7 +7,30 @@ cleanup() {
   AXERN_HOME="${smoke_root}" "${cli}" local down >/dev/null 2>&1 || true
   AXERN_HOME="${smoke_root}" "${cli}" local reset --force >/dev/null 2>&1 || true
 }
-trap cleanup EXIT
+
+diagnostics() {
+  echo "local release smoke failed; collecting diagnostics" >&2
+  for output in run.stdout run.stderr exit.stdout exit.stderr; do
+    if [[ -s "${smoke_root}/${output}" ]]; then
+      echo "--- ${output} ---" >&2
+      sed -n '1,240p' "${smoke_root}/${output}" >&2
+    fi
+  done
+  echo "--- local status ---" >&2
+  AXERN_HOME="${smoke_root}" "${cli}" --config "${smoke_root}/config.json" --timeout 30s local status >&2 || true
+  echo "--- local logs ---" >&2
+  AXERN_HOME="${smoke_root}" "${cli}" --config "${smoke_root}/config.json" --timeout 30s local logs --tail 200 >&2 || true
+}
+
+on_exit() {
+  status=$?
+  if [[ "${status}" -ne 0 ]]; then
+    diagnostics
+  fi
+  cleanup
+  return "${status}"
+}
+trap on_exit EXIT
 
 export AXERN_HOME="${smoke_root}"
 config="${smoke_root}/config.json"


### PR DESCRIPTION
## Summary

- give Run and Service allocation creation a dedicated 10-minute per-item lifecycle budget
- keep short lifecycle operations bounded to 60 seconds while preserving application shutdown cancellation
- remove the generic 30-second reconciler deadline from long-running allocation work
- print captured Run output, local status, and component logs when the source-free local release smoke fails

## Validation

- `go test ./internal/app ./internal/application/run ./internal/application/service ./internal/nodebridge ./internal/kernel/allocation`
- `make -C control/controld vet`
- `make -C control/controld check-architecture`
- `make agent-doc-check`
- `bash -n scripts/release/local-release-smoke.sh`
- `shellcheck scripts/release/local-release-smoke.sh`

Full source-free local and cross-architecture acceptance remains delegated to CI.