### PR TITLE
fix(local): safely reset root-owned data

### DIFF
--- a/apps/cli/internal/localruntime/manager.go
+++ b/apps/cli/internal/localruntime/manager.go
@@ -61,6 +61,7 @@ type Manager struct {
 	Stderr     io.Writer
 	Runner     Runner
 	Dir        string
+	removeAll  func(string) error
 }
 
 func New(version, configPath string, stdout, stderr io.Writer) (*Manager, error) {
@@ -209,25 +210,98 @@ func (m *Manager) down(ctx context.Context, removeVolumes bool) error {
 }
 
 func (m *Manager) Reset(ctx context.Context) error {
+	clean, err := m.validatedResetPath()
+	if err != nil {
+		return err
+	}
 	release, err := m.lock()
 	if err != nil {
 		return err
 	}
 	defer release()
+	helperImage := m.backupHelperImage()
 	if err := m.down(ctx, true); err != nil {
+		return err
+	}
+	if err := m.removeLocalData(ctx, clean, helperImage); err != nil {
 		return err
 	}
 	if err := m.removeContext(); err != nil {
 		return err
 	}
-	clean, err := filepath.Abs(m.Dir)
-	if err != nil || filepath.Base(clean) != "local" {
-		return fmt.Errorf("refusing to reset unexpected local path %q", m.Dir)
-	}
-	if err := os.RemoveAll(clean); err != nil {
-		return err
-	}
 	fmt.Fprintln(m.Stdout, "Axern local data was removed and cannot be recovered.")
+	return nil
+}
+
+func (m *Manager) validatedResetPath() (string, error) {
+	expected, err := DataDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve expected local data path: %w", err)
+	}
+	clean, err := filepath.Abs(m.Dir)
+	if err != nil {
+		return "", fmt.Errorf("resolve local data path %q: %w", m.Dir, err)
+	}
+	expected, err = filepath.Abs(expected)
+	if err != nil {
+		return "", fmt.Errorf("resolve expected local data path %q: %w", expected, err)
+	}
+	if clean != expected || filepath.Base(clean) != ContextName {
+		return "", fmt.Errorf("refusing to reset unexpected local path %q", m.Dir)
+	}
+	configPath := m.ConfigPath
+	if configPath == "" {
+		configPath = config.DefaultPath()
+	}
+	configPath, err = filepath.Abs(configPath)
+	if err != nil {
+		return "", fmt.Errorf("resolve Axern config path: %w", err)
+	}
+	if pathWithin(clean, configPath) {
+		return "", fmt.Errorf("refusing to reset local data containing Axern config %q; move --config outside %q first", configPath, clean)
+	}
+	info, err := os.Lstat(clean)
+	if err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return "", fmt.Errorf("refusing to reset symlinked local path %q", m.Dir)
+		}
+		if !info.IsDir() {
+			return "", fmt.Errorf("refusing to reset non-directory local path %q", m.Dir)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", fmt.Errorf("inspect local data path %q: %w", m.Dir, err)
+	}
+	return clean, nil
+}
+
+func pathWithin(root, path string) bool {
+	relative, err := filepath.Rel(root, path)
+	return err == nil && relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator))
+}
+
+func (m *Manager) removeLocalData(ctx context.Context, clean, helperImage string) error {
+	removeAll := os.RemoveAll
+	if m.removeAll != nil {
+		removeAll = m.removeAll
+	}
+	hostErr := removeAll(clean)
+	if hostErr == nil {
+		return nil
+	}
+	if err := os.MkdirAll(clean, 0o700); err != nil {
+		return fmt.Errorf("prepare local data cleanup after %v: %w", hostErr, err)
+	}
+	script := `set -eu
+for path in /source/* /source/.[!.]* /source/..?*; do
+  [ -e "$path" ] || [ -L "$path" ] || continue
+  rm -rf -- "$path"
+done`
+	if err := m.Runner.Run(ctx, m.Stdout, m.Stderr, "docker", "run", "--rm", "--network", "none", "--read-only", "--user", "0:0", "--entrypoint", "/bin/sh", "-v", clean+":/source", helperImage, "-c", script); err != nil {
+		return fmt.Errorf("remove root-owned local data after host cleanup failed (%v): %w", hostErr, err)
+	}
+	if err := removeAll(clean); err != nil {
+		return fmt.Errorf("remove local data after root cleanup: %w", err)
+	}
 	return nil
 }
 
@@ -341,7 +415,7 @@ func (m *Manager) backupHelperImage() string {
 			}
 		}
 	}
-	return "postgres:16-alpine"
+	return localbundle.ImageReferences(m.Version)["POSTGRES_IMAGE"]
 }
 
 func versionLess(left, right string) bool {

--- a/apps/cli/internal/localruntime/reset_test.go
+++ b/apps/cli/internal/localruntime/reset_test.go
@@ -1,0 +1,171 @@
+package localruntime
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/cofy-x/axern/apps/cli/internal/config"
+)
+
+func TestResetRemovesRootOwnedDataWithLockedHelperImage(t *testing.T) {
+	manager, runner := newResetTestManager(t)
+	removeCalls := 0
+	manager.removeAll = func(path string) error {
+		removeCalls++
+		if removeCalls == 1 {
+			return os.ErrPermission
+		}
+		return os.RemoveAll(path)
+	}
+
+	if err := manager.Reset(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if removeCalls != 2 {
+		t.Fatalf("remove calls = %d, want 2", removeCalls)
+	}
+	if _, err := os.Stat(manager.Dir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("local directory still exists: %v", err)
+	}
+	if len(runner.calls) != 2 {
+		t.Fatalf("runner calls = %#v, want compose down and cleanup helper", runner.calls)
+	}
+	wantHelper := []string{
+		"docker", "run", "--rm", "--network", "none", "--read-only", "--user", "0:0",
+		"--entrypoint", "/bin/sh", "-v", manager.Dir + ":/source", "example.invalid/postgres@sha256:locked", "-c",
+	}
+	if len(runner.calls[1]) < len(wantHelper) {
+		t.Fatalf("cleanup helper = %#v, want prefix %#v", runner.calls[1], wantHelper)
+	}
+	if got := runner.calls[1][:len(wantHelper)]; !reflect.DeepEqual(got, wantHelper) {
+		t.Fatalf("cleanup helper = %#v, want prefix %#v", runner.calls[1], wantHelper)
+	}
+	cfg, err := config.Load(manager.ConfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := cfg.Contexts[ContextName]; ok || cfg.CurrentContext == ContextName {
+		t.Fatalf("local context was not removed: %#v", cfg)
+	}
+}
+
+func TestResetKeepsContextWhenRootCleanupFails(t *testing.T) {
+	manager, runner := newResetTestManager(t)
+	manager.removeAll = func(string) error { return os.ErrPermission }
+	runner.helperErr = errors.New("cleanup helper failed")
+
+	err := manager.Reset(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "remove root-owned local data") {
+		t.Fatalf("Reset() error = %v", err)
+	}
+	cfg, loadErr := config.Load(manager.ConfigPath)
+	if loadErr != nil {
+		t.Fatal(loadErr)
+	}
+	if _, ok := cfg.Contexts[ContextName]; !ok || cfg.CurrentContext != ContextName {
+		t.Fatalf("local context changed after failed cleanup: %#v", cfg)
+	}
+}
+
+func TestResetRejectsUnexpectedAndSymlinkedPathsBeforeDocker(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("AXERN_HOME", root)
+	for _, test := range []struct {
+		name string
+		dir  func(*testing.T) string
+		want string
+	}{
+		{
+			name: "unexpected path",
+			dir: func(t *testing.T) string {
+				return filepath.Join(t.TempDir(), ContextName)
+			},
+			want: "unexpected local path",
+		},
+		{
+			name: "symlinked path",
+			dir: func(t *testing.T) string {
+				target := filepath.Join(t.TempDir(), ContextName)
+				if err := os.MkdirAll(target, 0o700); err != nil {
+					t.Fatal(err)
+				}
+				path := filepath.Join(root, ContextName)
+				if err := os.Symlink(target, path); err != nil {
+					t.Fatal(err)
+				}
+				return path
+			},
+			want: "symlinked local path",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			runner := &resetRunner{}
+			manager := &Manager{Dir: test.dir(t), ConfigPath: filepath.Join(root, "config.json"), Runner: runner, Stdout: io.Discard, Stderr: io.Discard}
+			err := manager.Reset(context.Background())
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("Reset() error = %v, want %q", err, test.want)
+			}
+			if len(runner.calls) != 0 {
+				t.Fatalf("unsafe reset invoked Docker: %#v", runner.calls)
+			}
+		})
+	}
+}
+
+func TestResetRejectsConfigInsideLocalData(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("AXERN_HOME", root)
+	dir := filepath.Join(root, ContextName)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	runner := &resetRunner{}
+	manager := &Manager{Dir: dir, ConfigPath: filepath.Join(dir, "config.json"), Runner: runner, Stdout: io.Discard, Stderr: io.Discard}
+	err := manager.Reset(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "containing Axern config") {
+		t.Fatalf("Reset() error = %v", err)
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("unsafe reset invoked Docker: %#v", runner.calls)
+	}
+}
+
+func newResetTestManager(t *testing.T) (*Manager, *resetRunner) {
+	t.Helper()
+	root := t.TempDir()
+	t.Setenv("AXERN_HOME", root)
+	dir := filepath.Join(root, ContextName)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "compose.env"), []byte("POSTGRES_IMAGE=\"example.invalid/postgres@sha256:locked\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runner := &resetRunner{}
+	manager := &Manager{Version: "0.4.0", Dir: dir, ConfigPath: filepath.Join(root, "config.json"), Runner: runner, Stdout: io.Discard, Stderr: io.Discard}
+	if err := manager.writeContext(true); err != nil {
+		t.Fatal(err)
+	}
+	return manager, runner
+}
+
+type resetRunner struct {
+	calls     [][]string
+	helperErr error
+}
+
+func (r *resetRunner) Run(_ context.Context, _, _ io.Writer, name string, args ...string) error {
+	r.calls = append(r.calls, append([]string{name}, args...))
+	if len(args) > 0 && args[0] == "run" {
+		return r.helperErr
+	}
+	return nil
+}
+
+func (*resetRunner) Output(context.Context, string, ...string) ([]byte, error) { return nil, nil }


### PR DESCRIPTION
## Summary

- validate that reset targets only the configured non-symlinked local data directory
- fall back to a network-isolated root cleanup helper when containers leave host-unremovable bind-mount data
- remove the local context only after data cleanup succeeds
- use the release-locked PostgreSQL image for cleanup and cover success, failure, and path-safety cases

## Root cause

The source-free release smoke completed local startup, stdout/stderr streaming, exit-code propagation, down, and restart on both architectures. The final reset failed because MinIO and axnoded created root-owned files in bind mounts that the host CLI could not remove with `os.RemoveAll`.

## Validation

- `go test ./apps/cli/...`
- `go vet ./apps/cli/...`
- `make axern-cli-check-architecture`
- `make axern-cli-build`
- `make release-check`
- `make agent-doc-check`
- real temporary root-owned directory cleanup using the built CLI and Docker
