### PR TITLE
fix(release): gate public distribution readiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,32 @@ jobs:
       - name: Check Grafana asset copies
         run: make grafana-assets-check
 
+  release-contracts:
+    name: Release Contracts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version: "1.25.12"
+          cache: false
+
+      - name: Set up Helm
+        run: |
+          bash scripts/release/install-helm.sh "${RUNNER_TEMP}/bin/helm"
+          echo "${RUNNER_TEMP}/bin" >> "${GITHUB_PATH}"
+
+      - name: Install workflow validator
+        run: go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.7
+
+      - name: Validate workflows and release contracts
+        run: |
+          actionlint .github/workflows/*.yml
+          make release-check
+
   go:
     name: Go
     runs-on: ubuntu-latest

--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -1,0 +1,156 @@
+name: Homebrew
+
+on:
+  workflow_run:
+    workflows: [Release]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Stable Axern version to publish, with or without a leading v
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: homebrew-axern-${{ github.event_name == 'workflow_dispatch' && inputs.version || github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      startsWith(github.event.workflow_run.head_branch, 'v'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      tag: ${{ steps.release.outputs.tag }}
+      version: ${{ steps.release.outputs.version }}
+    steps:
+      - name: Resolve stable release
+        id: release
+        env:
+          REQUESTED_RELEASE: ${{ github.event_name == 'workflow_dispatch' && inputs.version || github.event.workflow_run.head_branch }}
+          EXPECTED_SHA: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || '' }}
+          WORKFLOW_EVENT: ${{ github.event_name }}
+          WORKFLOW_REF_NAME: ${{ github.ref_name }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          if [[ "${WORKFLOW_EVENT}" == workflow_dispatch && "${WORKFLOW_REF_NAME}" != "${DEFAULT_BRANCH}" ]]; then
+            echo "manual Homebrew publication must run from ${DEFAULT_BRANCH}" >&2
+            exit 2
+          fi
+          version="${REQUESTED_RELEASE#v}"
+          if [[ ! "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Homebrew publication requires a stable semantic version; got ${REQUESTED_RELEASE}" >&2
+            exit 2
+          fi
+          {
+            echo "tag=v${version}"
+            echo "version=${version}"
+            echo "expected_sha=${EXPECTED_SHA}"
+          } >> "${GITHUB_OUTPUT}"
+      - name: Checkout immutable Axern release
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ steps.release.outputs.tag }}
+          fetch-depth: 0
+          path: axern
+      - name: Verify release identity
+        env:
+          AXERN_RELEASE_TAG: ${{ steps.release.outputs.tag }}
+          AXERN_RELEASE_VERSION: ${{ steps.release.outputs.version }}
+          EXPECTED_SHA: ${{ steps.release.outputs.expected_sha }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          test "$(cat axern/VERSION)" = "${AXERN_RELEASE_VERSION}"
+          test "$(git -C axern cat-file -t "refs/tags/${AXERN_RELEASE_TAG}")" = tag
+          release_sha="$(git -C axern rev-list -n 1 "${AXERN_RELEASE_TAG}")"
+          if [[ -n "${EXPECTED_SHA}" && "${release_sha}" != "${EXPECTED_SHA}" ]]; then
+            echo "Homebrew release ${AXERN_RELEASE_TAG} points to ${release_sha}, want ${EXPECTED_SHA}" >&2
+            exit 1
+          fi
+          release="$(gh release view "${AXERN_RELEASE_TAG}" --repo cofy-x/axern --json tagName,isDraft,isPrerelease)"
+          jq -e --arg tag "${AXERN_RELEASE_TAG}" \
+            '.tagName == $tag and .isDraft == false and .isPrerelease == false' <<<"${release}" >/dev/null
+      - name: Download immutable release checksums
+        env:
+          AXERN_RELEASE_TAG: ${{ steps.release.outputs.tag }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p axern/dist/release
+          gh release download "${AXERN_RELEASE_TAG}" --repo cofy-x/axern \
+            --pattern checksums.txt --dir axern/dist/release
+      - name: Generate and validate formula
+        run: bash axern/scripts/release/homebrew-formula-check.sh "${RUNNER_TEMP}/axern.rb"
+      - name: Upload immutable formula
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: homebrew-formula
+          path: ${{ runner.temp }}/axern.rb
+          if-no-files-found: error
+
+  publish:
+    needs: prepare
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: homebrew-release
+    steps:
+      - name: Verify Homebrew credential
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          if [[ -z "${HOMEBREW_TAP_TOKEN}" ]]; then
+            echo "homebrew-release must provide HOMEBREW_TAP_TOKEN with contents write access to cofy-x/homebrew-tap" >&2
+            exit 1
+          fi
+      - name: Checkout trusted publisher
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ github.sha }}
+          path: publisher
+      - name: Download immutable formula
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: homebrew-formula
+          path: dist/homebrew
+      - name: Checkout Homebrew tap
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          repository: cofy-x/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: homebrew-tap
+      - name: Reconcile immutable formula
+        id: formula
+        run: >-
+          python3 publisher/scripts/release/homebrew_formula_reconcile.py
+          dist/homebrew/axern.rb homebrew-tap/Formula/axern.rb
+      - name: Publish formula
+        if: steps.formula.outputs.homebrew_formula_changed == 'true'
+        working-directory: homebrew-tap
+        env:
+          AXERN_RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git add Formula/axern.rb
+          git commit -m "axern ${AXERN_RELEASE_VERSION}"
+          git push origin HEAD:main
+
+  verify:
+    needs: [prepare, publish]
+    runs-on: macos-14
+    timeout-minutes: 20
+    steps:
+      - name: Install from the public tap
+        env:
+          AXERN_RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          brew tap cofy-x/tap
+          brew install cofy-x/tap/axern
+          "$(brew --prefix axern)/bin/axern" version | grep -F "${AXERN_RELEASE_VERSION}"
+          brew test cofy-x/tap/axern

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -382,9 +382,30 @@ jobs:
           gh release create "${GITHUB_REF_NAME}" dist/release/* \
             "${release_args[@]}"
 
+  sdk-publication-readiness:
+    if: github.ref_type == 'tag'
+    needs: [publish, sdk-artifacts]
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version: "1.25.12"
+          cache: false
+      - name: Download SDK artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: sdk-artifacts
+          path: dist/sdk
+      - name: Wait for immutable SDK publication
+        run: python3 scripts/release/sdk_publication_readiness.py
+
   acceptance:
     if: github.ref_type == 'tag'
-    needs: [publish, sdk-publish]
+    needs: [sdk-publication-readiness]
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -426,35 +447,3 @@ jobs:
         run: |
           bash scripts/release/kind-acceptance.sh \
             bash scripts/release/sdk-data-plane-acceptance.sh published
-
-  homebrew:
-    if: github.ref_type == 'tag' && vars.HOMEBREW_TAP_ENABLED == 'true'
-    needs: [acceptance]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Axern
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-        with:
-          path: axern
-      - name: Download release artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        with:
-          name: release-artifacts
-          path: axern/dist/release
-      - name: Checkout Homebrew tap
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-        with:
-          repository: cofy-x/homebrew-tap
-          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-          path: homebrew-tap
-      - name: Update formula
-        run: bash axern/scripts/release/homebrew-formula-check.sh "${GITHUB_WORKSPACE}/homebrew-tap/Formula/axern.rb"
-      - name: Publish formula
-        working-directory: homebrew-tap
-        run: |
-          git config user.name github-actions[bot]
-          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-          git add Formula/axern.rb
-          git diff --cached --quiet && exit 0
-          git commit -m "axern ${GITHUB_REF_NAME}"
-          git push

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Axrun CI](https://github.com/cofy-x/axern/actions/workflows/axrun-ci.yml/badge.svg)](https://github.com/cofy-x/axern/actions/workflows/axrun-ci.yml)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](./LICENSE)
 
-[Documentation](https://axern.cofy-x.space) · [Quickstart](https://axern.cofy-x.space/getting-started/compose/) · [SDKs](https://axern.cofy-x.space/sdk/)
+[Documentation](https://axern.cofy-x.space) · [Quickstart](https://axern.cofy-x.space/getting-started/) · [SDKs](https://axern.cofy-x.space/sdk/)
 
 Axern is an open-source sandbox platform for AI agents. It isolates untrusted
 agent-generated code with runsc and runs trusted long-lived services with runc
@@ -35,6 +35,17 @@ source checkout. It needs only the `axern` CLI and Docker Compose v2.
 
 ```bash
 brew install cofy-x/tap/axern
+```
+
+Without Homebrew, use the standalone checksummed installer:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/cofy-x/axern/main/install.sh | sh
+```
+
+Then start Axern and run the first workload:
+
+```bash
 axern local up
 axern run python:3.12-slim -- python -c 'print("hello from axern")'
 ```

--- a/docs/operations/releases.md
+++ b/docs/operations/releases.md
@@ -33,6 +33,13 @@ configure trust and remove the bootstrap credential before creating the release
 tags. npm generates provenance automatically for subsequent public OIDC
 publishes.
 
+Homebrew publication uses a separate `Homebrew` workflow so a tap outage or
+credential problem never requires rebuilding immutable release artifacts. Its
+`homebrew-release` environment must provide `HOMEBREW_TAP_TOKEN`, a
+fine-grained token with Contents write access only to
+`cofy-x/homebrew-tap`. Protect that environment independently from
+`sdk-release`; do not expose the tap credential to the release-tag checkout.
+
 The release tag must point at a commit already accepted by the normal `main`
 branch checks. Releases are immutable: never move an existing tag or overwrite
 a GitHub Release, OCI chart version, or final image tag.
@@ -87,30 +94,51 @@ mismatched Go SDK tag. The workflow then:
    publishing;
 10. publishes multi-architecture GHCR manifests and the OCI Helm chart;
 11. attests and attaches the release files to a GitHub Release;
-12. repeats the source-free local smoke, fresh-kind Run, and complete SDK
-    data-plane acceptance from
-    anonymously readable PyPI, npm, and Go module artifacts.
+12. waits in one bounded readiness gate until PyPI and npm expose the exact
+    candidate digests and the public Go proxy plus checksum database resolve
+    the expected Go tag commit;
+13. repeats the source-free local smoke, fresh-kind Run, and complete SDK
+    data-plane acceptance from anonymously readable PyPI, npm, and Go module
+    artifacts on Linux amd64 and arm64.
 
-After published acceptance succeeds, the Homebrew job updates
-`cofy-x/homebrew-tap`. Set the repository variable `HOMEBREW_TAP_ENABLED` to
-`true` and provide `HOMEBREW_TAP_TOKEN` as a fine-grained credential with
-contents write access only to that tap repository. Keep the job disabled until
-both settings are present; the release itself remains usable through its
-archives when Homebrew publication is intentionally disabled.
+Do not query the final Go module version through `proxy.golang.org` before the
+two release tags exist. A pre-release 404 can remain in public negative caches
+after the tag is pushed. Preflight checks use Git refs to prove that a version
+is unused; the readiness gate owns public Go module propagation after publish.
 
 Registry publication is safely repeatable but remains immutable. On a rerun,
 the workflow skips an SDK version only when every PyPI filename and SHA-256, or
 the npm tarball SHA-1, exactly matches the candidate built by the workflow. An
 existing version with different bytes fails the release instead of being
-overwritten. A tag that starts a release is consumed even when publication
-fails: fix the root cause, advance the coherent version, and create new tags.
-Never move or reuse the failed tags.
+overwritten. A tag that starts a release is always consumed and must never be
+moved. Advance the coherent version when a code or artifact fix is required.
+When all immutable artifacts already match and only registry propagation or a
+downstream acceptance step failed, rerun the failed jobs against the same tags.
 
 Container images carry the public source-repository label and the chart carries
 matching source metadata so GHCR associates packages with this public
 repository. After the first release, confirm that every image and
 `charts/axern` allow anonymous reads. A release is not complete while any
 package remains private.
+
+## Publish Homebrew
+
+After a successful tag-triggered `Release` run, the independent `Homebrew`
+workflow prepares the formula without credentials, publishes it through the
+protected `homebrew-release` environment, and verifies a real installation on
+macOS. Formula reconciliation is idempotent: it creates or upgrades
+`Formula/axern.rb`, rejects downgrades, and rejects different content for an
+already-published version.
+
+The workflow also supports an explicit backfill for a completed release:
+
+```bash
+gh workflow run homebrew.yml --ref main -f version="$(cat VERSION)"
+```
+
+Use backfill when the workflow was introduced after a release or when tap
+credentials were unavailable at release time. It consumes the immutable
+GitHub Release checksums and never rebuilds CLI archives.
 
 ## Verify
 
@@ -124,9 +152,13 @@ helm show chart oci://ghcr.io/cofy-x/charts/axern --version "$(cat VERSION)"
 uv run --no-project --with "axern-sdk==$(cat VERSION)" -- python -c 'import axern_sdk; print(axern_sdk.__version__)'
 npm view "@cofy-x/axern-sdk@$(cat VERSION)" version
 go list -m "github.com/cofy-x/axern/sdk/go@v$(cat VERSION)"
+brew install cofy-x/tap/axern
+axern version
 ```
 
 The GitHub Release must contain four CLI archives, `checksums.txt`, SPDX and
 CycloneDX SBOMs, and the matching Helm package. The quickstart and Kubernetes
 commands in the root README are the public installation contract and must be
-rerun when those paths change.
+rerun when those paths change. A release is not fully distributed until the
+independent Homebrew workflow succeeds or the tap is explicitly declared
+unavailable in user-facing installation documentation.

--- a/mk/root.mk
+++ b/mk/root.mk
@@ -75,6 +75,7 @@ release-check: ## Verify release versions and package contracts
 	bash $(ROOTDIR)/scripts/dev-env/docker-build-cache-test.sh
 	bash $(ROOTDIR)/scripts/release/image-build-contract-check.sh
 	bash $(ROOTDIR)/scripts/proxy-env-contract-check.sh
+	bash $(ROOTDIR)/scripts/release/publication-contract-check.sh
 	bash $(ROOTDIR)/scripts/release/sdk-data-plane-contract-check.sh
 	$(MAKE) helm-lint
 

--- a/scripts/release/homebrew_formula_reconcile.py
+++ b/scripts/release/homebrew_formula_reconcile.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Reconcile an immutable Axern formula into the official Homebrew tap."""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import re
+import sys
+import tempfile
+
+
+VERSION_PATTERN = re.compile(r'^\s*version "([0-9]+)\.([0-9]+)\.([0-9]+)"\s*$', re.MULTILINE)
+
+
+class FormulaError(RuntimeError):
+    pass
+
+
+def formula_version(content: bytes, label: str) -> tuple[int, int, int]:
+    try:
+        text = content.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise FormulaError(f"{label} is not UTF-8") from error
+    match = VERSION_PATTERN.search(text)
+    if not match:
+        raise FormulaError(f"{label} does not declare a stable semantic version")
+    return int(match.group(1)), int(match.group(2)), int(match.group(3))
+
+
+def atomic_write(path: pathlib.Path, content: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path: pathlib.Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(dir=path.parent, prefix=f".{path.name}.", delete=False) as handle:
+            handle.write(content)
+            temporary_path = pathlib.Path(handle.name)
+        temporary_path.chmod(0o644)
+        os.replace(temporary_path, path)
+        temporary_path = None
+    finally:
+        if temporary_path is not None:
+            temporary_path.unlink(missing_ok=True)
+
+
+def reconcile(candidate: pathlib.Path, target: pathlib.Path) -> bool:
+    candidate_content = candidate.read_bytes()
+    candidate_version = formula_version(candidate_content, str(candidate))
+    if not target.exists():
+        atomic_write(target, candidate_content)
+        return True
+
+    target_content = target.read_bytes()
+    target_version = formula_version(target_content, str(target))
+    if target_version > candidate_version:
+        raise FormulaError(
+            f"refusing Homebrew formula downgrade from {target_version} to {candidate_version}"
+        )
+    if target_version == candidate_version:
+        if target_content != candidate_content:
+            raise FormulaError(
+                f"Homebrew formula version {candidate_version} already exists with different content"
+            )
+        return False
+
+    atomic_write(target, candidate_content)
+    return True
+
+
+def output(name: str, value: str) -> None:
+    print(f"{name}={value}")
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if github_output:
+        with pathlib.Path(github_output).open("a", encoding="utf-8") as handle:
+            handle.write(f"{name}={value}\n")
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print(f"usage: {sys.argv[0]} CANDIDATE TARGET", file=sys.stderr)
+        return 2
+    candidate = pathlib.Path(sys.argv[1])
+    target = pathlib.Path(sys.argv[2])
+    try:
+        changed = reconcile(candidate, target)
+    except (FormulaError, OSError) as error:
+        print(f"Homebrew formula reconciliation failed: {error}", file=sys.stderr)
+        return 1
+    output("homebrew_formula_changed", str(changed).lower())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release/homebrew_formula_reconcile_test.py
+++ b/scripts/release/homebrew_formula_reconcile_test.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import pathlib
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+import homebrew_formula_reconcile as formula
+
+
+def content(version: str, suffix: str = "") -> bytes:
+    return f'class Axern < Formula\n  version "{version}"\n{suffix}end\n'.encode()
+
+
+class HomebrewFormulaReconcileTest(unittest.TestCase):
+    def test_creates_missing_formula_and_is_idempotent(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = pathlib.Path(temporary)
+            candidate = root / "candidate.rb"
+            target = root / "Formula" / "axern.rb"
+            candidate.write_bytes(content("1.2.3"))
+            self.assertTrue(formula.reconcile(candidate, target))
+            self.assertEqual(target.read_bytes(), candidate.read_bytes())
+            self.assertFalse(formula.reconcile(candidate, target))
+
+    def test_upgrades_older_formula(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = pathlib.Path(temporary)
+            candidate = root / "candidate.rb"
+            target = root / "axern.rb"
+            candidate.write_bytes(content("1.3.0"))
+            target.write_bytes(content("1.2.9"))
+            self.assertTrue(formula.reconcile(candidate, target))
+            self.assertEqual(target.read_bytes(), candidate.read_bytes())
+
+    def test_rejects_downgrade(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = pathlib.Path(temporary)
+            candidate = root / "candidate.rb"
+            target = root / "axern.rb"
+            candidate.write_bytes(content("1.2.3"))
+            target.write_bytes(content("1.3.0"))
+            with self.assertRaisesRegex(formula.FormulaError, "downgrade"):
+                formula.reconcile(candidate, target)
+
+    def test_rejects_same_version_with_different_content(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = pathlib.Path(temporary)
+            candidate = root / "candidate.rb"
+            target = root / "axern.rb"
+            candidate.write_bytes(content("1.2.3", "  desc \"candidate\"\n"))
+            target.write_bytes(content("1.2.3", "  desc \"different\"\n"))
+            with self.assertRaisesRegex(formula.FormulaError, "different content"):
+                formula.reconcile(candidate, target)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/release/publication-contract-check.sh
+++ b/scripts/release/publication-contract-check.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+AXERN_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+python3 "${AXERN_ROOT}/scripts/release/sdk_publication_readiness_test.py"
+python3 "${AXERN_ROOT}/scripts/release/homebrew_formula_reconcile_test.py"
+
+python3 - "${AXERN_ROOT}" <<'PY'
+import ast
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1])
+release = (root / ".github/workflows/release.yml").read_text()
+homebrew = (root / ".github/workflows/homebrew.yml").read_text()
+ci = (root / ".github/workflows/ci.yml").read_text()
+
+for relative in (
+    "scripts/release/sdk_publication_readiness.py",
+    "scripts/release/homebrew_formula_reconcile.py",
+):
+    ast.parse((root / relative).read_text())
+
+for contract in (
+    "sdk-publication-readiness:",
+    "needs: [publish, sdk-artifacts]",
+    "timeout-minutes: 35",
+    "sdk_publication_readiness.py",
+    "needs: [sdk-publication-readiness]",
+):
+    if contract not in release:
+        raise SystemExit(f"release workflow is missing publication readiness contract: {contract}")
+for obsolete in ("\n  homebrew:\n", "HOMEBREW_TAP_TOKEN", "HOMEBREW_TAP_ENABLED"):
+    if obsolete in release:
+        raise SystemExit(f"release workflow retains coupled Homebrew publication: {obsolete.strip()}")
+
+for contract in (
+    "workflow_run:",
+    "workflow_dispatch:",
+    "workflows: [Release]",
+    "manual Homebrew publication must run from",
+    "environment: homebrew-release",
+    "repository: cofy-x/homebrew-tap",
+    "homebrew_formula_reconcile.py",
+    "brew install cofy-x/tap/axern",
+    "brew test cofy-x/tap/axern",
+):
+    if contract not in homebrew:
+        raise SystemExit(f"Homebrew workflow is missing publication contract: {contract}")
+
+prepare = homebrew.split("  prepare:\n", 1)[1].split("\n  publish:\n", 1)[0]
+if "secrets." in prepare or "HOMEBREW_TAP_TOKEN" in prepare:
+    raise SystemExit("Homebrew formula preparation must not receive cross-repository credentials")
+publish = homebrew.split("\n  publish:\n", 1)[1].split("\n  verify:\n", 1)[0]
+if "environment: homebrew-release" not in publish or "HOMEBREW_TAP_TOKEN" not in publish:
+    raise SystemExit("Homebrew publication must use the protected tap credential")
+
+preflight = (root / "scripts/release/sdk-preflight.sh").read_text()
+if "proxy.golang.org" in preflight or "sum.golang.org" in preflight:
+    raise SystemExit("pre-tag SDK preflight must not prime a negative Go module cache entry")
+
+for contract in ("name: Release Contracts", "actionlint .github/workflows/*.yml", "make release-check"):
+    if contract not in ci:
+        raise SystemExit(f"pull request CI is missing release contract gate: {contract}")
+PY
+
+echo "publication_contract_ok=true"

--- a/scripts/release/sdk-data-plane-contract-check.sh
+++ b/scripts/release/sdk-data-plane-contract-check.sh
@@ -39,9 +39,6 @@ for value in required_workflow:
         raise SystemExit(f"release workflow is missing SDK data-plane contract: {value}")
 if workflow.count("if: github.ref_type == 'tag'") != 4:
     raise SystemExit("release workflow must restrict all publication jobs to tag events")
-for value in ("homebrew:", "needs: [acceptance]", "cofy-x/homebrew-tap", "HOMEBREW_TAP_TOKEN"):
-    if value not in workflow:
-        raise SystemExit(f"release workflow is missing Homebrew publication contract: {value}")
 global_env = workflow.split("jobs:", 1)[0]
 if "AXERN_RELEASE_VERSION:" in global_env:
     raise SystemExit("candidate image version must not override SDK or CLI artifact versions globally")

--- a/scripts/release/sdk_publication_readiness.py
+++ b/scripts/release/sdk_publication_readiness.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Wait until the immutable SDK release is usable through public registries."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Callable, Mapping
+
+
+class NotReady(RuntimeError):
+    """The registry has not exposed the expected immutable release yet."""
+
+
+class IntegrityError(RuntimeError):
+    """The public release differs from the accepted candidate."""
+
+
+def fetch_json(url: str, label: str) -> object:
+    request = urllib.request.Request(
+        url,
+        headers={"Accept": "application/json", "User-Agent": "axern-release-readiness"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return json.load(response)
+    except urllib.error.HTTPError as error:
+        if error.code in {404, 408, 425, 429, 500, 502, 503, 504}:
+            raise NotReady(f"{label} returned HTTP {error.code}") from error
+        raise IntegrityError(f"{label} returned unexpected HTTP {error.code}") from error
+    except (TimeoutError, urllib.error.URLError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise NotReady(f"{label} is not readable: {error}") from error
+
+
+def file_digests(directory: pathlib.Path, algorithm: str) -> dict[str, str]:
+    if not directory.is_dir():
+        raise IntegrityError(f"candidate artifact directory is missing: {directory}")
+    digest = getattr(hashlib, algorithm)
+    files = {
+        path.name: digest(path.read_bytes()).hexdigest()
+        for path in directory.iterdir()
+        if path.is_file()
+    }
+    if not files:
+        raise IntegrityError(f"candidate artifact directory is empty: {directory}")
+    return files
+
+
+def check_pypi(
+    version: str,
+    dist: pathlib.Path,
+    fetch: Callable[[str, str], object] = fetch_json,
+) -> None:
+    url = f"https://pypi.org/pypi/axern-sdk/{version}/json"
+    document = fetch(url, "PyPI axern-sdk")
+    if not isinstance(document, dict):
+        raise NotReady("PyPI axern-sdk metadata is incomplete")
+    info = document.get("info")
+    if not isinstance(info, dict) or info.get("version") is None:
+        raise NotReady("PyPI axern-sdk metadata is incomplete")
+    if info.get("version") != version:
+        raise IntegrityError("PyPI axern-sdk metadata has an unexpected version")
+    try:
+        remote = {
+            item["filename"]: item["digests"]["sha256"]
+            for item in document["urls"]
+        }
+    except (KeyError, TypeError) as error:
+        raise NotReady("PyPI axern-sdk metadata is incomplete") from error
+    local = file_digests(dist / "python", "sha256")
+    if remote.items() <= local.items() and remote.keys() != local.keys():
+        raise NotReady("PyPI axern-sdk has not exposed every candidate file")
+    if remote != local:
+        raise IntegrityError(
+            f"PyPI axern-sdk files differ from the candidate: remote={remote!r} local={local!r}"
+        )
+
+
+def check_npm(
+    version: str,
+    dist: pathlib.Path,
+    fetch: Callable[[str, str], object] = fetch_json,
+) -> None:
+    url = f"https://registry.npmjs.org/@cofy-x%2Faxern-sdk/{version}"
+    document = fetch(url, "npm @cofy-x/axern-sdk")
+    if not isinstance(document, dict) or document.get("version") is None:
+        raise NotReady("npm @cofy-x/axern-sdk metadata is incomplete")
+    if document.get("version") != version:
+        raise IntegrityError("npm @cofy-x/axern-sdk metadata has an unexpected version")
+    tarball = dist / "typescript" / f"cofy-x-axern-sdk-{version}.tgz"
+    if not tarball.is_file():
+        raise IntegrityError(f"candidate npm artifact is missing: {tarball}")
+    local_sha1 = hashlib.sha1(tarball.read_bytes()).hexdigest()
+    try:
+        remote_sha1 = document["dist"]["shasum"]
+    except (KeyError, TypeError) as error:
+        raise NotReady("npm @cofy-x/axern-sdk metadata is incomplete") from error
+    if remote_sha1 != local_sha1:
+        raise IntegrityError("npm @cofy-x/axern-sdk differs from the candidate")
+
+
+def check_go(
+    version: str,
+    commit: str,
+    run: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+) -> None:
+    module = "github.com/cofy-x/axern/sdk/go"
+    with tempfile.TemporaryDirectory(prefix="axern-go-readiness-") as temporary:
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "GOCACHE": f"{temporary}/build-cache",
+                "GOMODCACHE": f"{temporary}/module-cache",
+                "GOPROXY": "https://proxy.golang.org",
+                "GOSUMDB": "sum.golang.org",
+                "GOWORK": "off",
+            }
+        )
+        result = run(
+            ["go", "mod", "download", "-json", f"{module}@v{version}"],
+            capture_output=True,
+            check=False,
+            env=environment,
+            text=True,
+        )
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip()
+        if "checksum mismatch" in detail.lower() or "security error" in detail.lower():
+            raise IntegrityError(f"Go module checksum verification failed: {detail}")
+        raise NotReady(f"Go module is not publicly resolvable: {detail}")
+    try:
+        document = json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        raise NotReady("Go module download returned incomplete metadata") from error
+    if document.get("Path") != module or document.get("Version") != f"v{version}":
+        raise IntegrityError("Go proxy resolved an unexpected module version")
+    if not document.get("Zip") or not document.get("Sum"):
+        raise NotReady("Go proxy has not exposed the complete module archive")
+    origin = document.get("Origin")
+    if not isinstance(origin, dict) or origin.get("Hash") != commit:
+        raise IntegrityError(
+            f"Go proxy origin does not match release commit {commit}: {origin!r}"
+        )
+    if origin.get("Ref") != f"refs/tags/sdk/go/v{version}":
+        raise IntegrityError(f"Go proxy resolved an unexpected release ref: {origin!r}")
+
+
+def wait_for_checks(
+    checks: Mapping[str, Callable[[], None]],
+    timeout_seconds: float,
+    poll_seconds: float,
+    monotonic: Callable[[], float] = time.monotonic,
+    sleep: Callable[[float], None] = time.sleep,
+) -> None:
+    if timeout_seconds <= 0 or poll_seconds <= 0:
+        raise ValueError("readiness timeout and poll interval must be positive")
+    deadline = monotonic() + timeout_seconds
+    pending = dict(checks)
+    reasons: dict[str, str] = {}
+    next_heartbeat = monotonic()
+    while pending:
+        for name, check in tuple(pending.items()):
+            try:
+                check()
+            except NotReady as error:
+                reasons[name] = str(error)
+            else:
+                print(f"sdk_publication_ready={name}", flush=True)
+                pending.pop(name)
+                reasons.pop(name, None)
+        if not pending:
+            return
+        now = monotonic()
+        if now >= deadline:
+            summary = "; ".join(f"{name}: {reasons.get(name, 'not ready')}" for name in pending)
+            raise NotReady(f"SDK publication readiness timed out: {summary}")
+        if now >= next_heartbeat:
+            summary = "; ".join(f"{name}: {reasons.get(name, 'not ready')}" for name in pending)
+            print(f"sdk_publication_waiting={summary}", flush=True)
+            next_heartbeat = now + 60
+        sleep(min(poll_seconds, deadline - now))
+
+
+def repository_root() -> pathlib.Path:
+    return pathlib.Path(__file__).resolve().parents[2]
+
+
+def main() -> int:
+    root = repository_root()
+    version = (root / "VERSION").read_text().strip()
+    dist = pathlib.Path(os.environ.get("AXERN_SDK_DIST", root / "dist/sdk"))
+    commit = os.environ.get("GITHUB_SHA")
+    if not commit:
+        commit = subprocess.check_output(
+            ["git", "-C", str(root), "rev-parse", "HEAD"], text=True
+        ).strip()
+    try:
+        timeout_seconds = float(
+            os.environ.get("AXERN_PUBLICATION_READINESS_TIMEOUT_SECONDS", "1800")
+        )
+        poll_seconds = float(os.environ.get("AXERN_PUBLICATION_READINESS_POLL_SECONDS", "15"))
+        checks = {
+            "pypi": lambda: check_pypi(version, dist),
+            "npm": lambda: check_npm(version, dist),
+            "go": lambda: check_go(version, commit),
+        }
+        wait_for_checks(checks, timeout_seconds, poll_seconds)
+    except (IntegrityError, NotReady, ValueError) as error:
+        print(f"sdk publication readiness failed: {error}", file=sys.stderr)
+        return 1
+    print(f"sdk_publication_readiness_ok={version}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release/sdk_publication_readiness_test.py
+++ b/scripts/release/sdk_publication_readiness_test.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import hashlib
+import json
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+import urllib.error
+from unittest import mock
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+import sdk_publication_readiness as readiness
+
+
+class PublicationReadinessTest(unittest.TestCase):
+    def test_registry_404_is_retryable(self) -> None:
+        error = urllib.error.HTTPError(
+            "https://registry.example/version",
+            404,
+            "Not Found",
+            hdrs=None,
+            fp=None,
+        )
+        with mock.patch("urllib.request.urlopen", side_effect=error):
+            with self.assertRaises(readiness.NotReady):
+                readiness.fetch_json("https://registry.example/version", "registry")
+
+    def test_pypi_and_npm_match_candidate_artifacts(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            dist = pathlib.Path(temporary)
+            (dist / "python").mkdir()
+            (dist / "typescript").mkdir()
+            wheel = dist / "python" / "axern_sdk-1.2.3-py3-none-any.whl"
+            source = dist / "python" / "axern_sdk-1.2.3.tar.gz"
+            npm = dist / "typescript" / "cofy-x-axern-sdk-1.2.3.tgz"
+            wheel.write_bytes(b"wheel")
+            source.write_bytes(b"source")
+            npm.write_bytes(b"npm")
+
+            pypi = {
+                "info": {"version": "1.2.3"},
+                "urls": [
+                    {"filename": path.name, "digests": {"sha256": hashlib.sha256(path.read_bytes()).hexdigest()}}
+                    for path in (wheel, source)
+                ],
+            }
+            npm_document = {
+                "version": "1.2.3",
+                "dist": {"shasum": hashlib.sha1(npm.read_bytes()).hexdigest()},
+            }
+            readiness.check_pypi("1.2.3", dist, lambda _url, _label: pypi)
+            readiness.check_npm("1.2.3", dist, lambda _url, _label: npm_document)
+
+    def test_pypi_digest_mismatch_is_fatal(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            dist = pathlib.Path(temporary)
+            (dist / "python").mkdir()
+            artifact = dist / "python" / "axern_sdk-1.2.3.tar.gz"
+            artifact.write_bytes(b"candidate")
+            document = {
+                "info": {"version": "1.2.3"},
+                "urls": [{"filename": artifact.name, "digests": {"sha256": "0" * 64}}],
+            }
+            with self.assertRaises(readiness.IntegrityError):
+                readiness.check_pypi("1.2.3", dist, lambda _url, _label: document)
+
+    def test_partial_pypi_file_set_is_retryable(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            dist = pathlib.Path(temporary)
+            (dist / "python").mkdir()
+            wheel = dist / "python" / "axern_sdk-1.2.3-py3-none-any.whl"
+            source = dist / "python" / "axern_sdk-1.2.3.tar.gz"
+            wheel.write_bytes(b"wheel")
+            source.write_bytes(b"source")
+            document = {
+                "info": {"version": "1.2.3"},
+                "urls": [
+                    {
+                        "filename": wheel.name,
+                        "digests": {"sha256": hashlib.sha256(wheel.read_bytes()).hexdigest()},
+                    }
+                ],
+            }
+            with self.assertRaises(readiness.NotReady):
+                readiness.check_pypi("1.2.3", dist, lambda _url, _label: document)
+
+    def test_go_requires_public_archive_checksum_and_release_origin(self) -> None:
+        document = {
+            "Path": "github.com/cofy-x/axern/sdk/go",
+            "Version": "v1.2.3",
+            "Zip": "/tmp/module.zip",
+            "Sum": "h1:example",
+            "Origin": {
+                "Hash": "abc123",
+                "Ref": "refs/tags/sdk/go/v1.2.3",
+            },
+        }
+        observed_environment: dict[str, str] = {}
+
+        def run(_command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+            observed_environment.update(kwargs["env"])  # type: ignore[arg-type]
+            return subprocess.CompletedProcess([], 0, json.dumps(document), "")
+
+        readiness.check_go("1.2.3", "abc123", run)
+        self.assertEqual(observed_environment["GOPROXY"], "https://proxy.golang.org")
+        self.assertEqual(observed_environment["GOSUMDB"], "sum.golang.org")
+        self.assertNotIn("direct", observed_environment["GOPROXY"])
+
+    def test_go_unknown_revision_is_retryable(self) -> None:
+        def run(_command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+            return subprocess.CompletedProcess([], 1, "", "unknown revision sdk/go/v1.2.3")
+
+        with self.assertRaises(readiness.NotReady):
+            readiness.check_go("1.2.3", "abc123", run)
+
+    def test_go_origin_mismatch_is_fatal(self) -> None:
+        document = {
+            "Path": "github.com/cofy-x/axern/sdk/go",
+            "Version": "v1.2.3",
+            "Zip": "/tmp/module.zip",
+            "Sum": "h1:example",
+            "Origin": {
+                "Hash": "different",
+                "Ref": "refs/tags/sdk/go/v1.2.3",
+            },
+        }
+
+        def run(_command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+            return subprocess.CompletedProcess([], 0, json.dumps(document), "")
+
+        with self.assertRaisesRegex(readiness.IntegrityError, "release commit"):
+            readiness.check_go("1.2.3", "abc123", run)
+
+    def test_wait_retries_only_pending_checks(self) -> None:
+        clock = [0.0]
+        attempts = {"ready": 0, "delayed": 0}
+
+        def ready() -> None:
+            attempts["ready"] += 1
+
+        def delayed() -> None:
+            attempts["delayed"] += 1
+            if attempts["delayed"] < 3:
+                raise readiness.NotReady("registry returned HTTP 404")
+
+        def sleep(seconds: float) -> None:
+            clock[0] += seconds
+
+        readiness.wait_for_checks(
+            {"ready": ready, "delayed": delayed},
+            timeout_seconds=10,
+            poll_seconds=1,
+            monotonic=lambda: clock[0],
+            sleep=sleep,
+        )
+        self.assertEqual(attempts, {"ready": 1, "delayed": 3})
+
+    def test_wait_reports_timeout(self) -> None:
+        clock = [0.0]
+
+        def pending() -> None:
+            raise readiness.NotReady("still propagating")
+
+        def sleep(seconds: float) -> None:
+            clock[0] += seconds
+
+        with self.assertRaisesRegex(readiness.NotReady, "still propagating"):
+            readiness.wait_for_checks(
+                {"go": pending},
+                timeout_seconds=2,
+                poll_seconds=1,
+                monotonic=lambda: clock[0],
+                sleep=sleep,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a single immutable SDK publication-readiness gate between publish and the amd64/arm64 acceptance matrix
- verify PyPI and npm candidate digests plus the public Go proxy, checksum database, tag ref, and release commit with bounded propagation polling
- move Homebrew delivery into an independently retryable workflow with credential-free formula preparation, protected tap publication, idempotent reconciliation, and a real macOS brew install test
- add a Release Contracts PR check, deterministic readiness/reconciliation tests, an install-script fallback, and updated release operations

## Release boundary

This does not change or rebuild v0.4.1 artifacts and does not require v0.4.2. The completed v0.4.1 release remains immutable. After merge, configure the homebrew-release environment with HOMEBREW_TAP_TOKEN scoped to Contents write on cofy-x/homebrew-tap, then manually dispatch homebrew.yml for version 0.4.1 to backfill Formula/axern.rb.

## Validation

- actionlint on every GitHub workflow
- make release-check
- make agent-doc-check
- make open-source-check
- make docs-check
- Ruff and 13 deterministic publication tests
- real v0.4.1 SDK artifacts validated against public PyPI, npm, Go proxy, and sum.golang.org
- real v0.4.1 release checksums generated and reconciled into a Homebrew formula twice, proving create and idempotent no-op behavior
- real Go module archive resolved with the expected v0.4.1 tag and commit