### PR TITLE
chore(ci): upgrade release actions to Node 24

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Generate and validate formula
         run: bash axern/scripts/release/homebrew-formula-check.sh "${RUNNER_TEMP}/axern.rb"
       - name: Upload immutable formula
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: homebrew-formula
           path: ${{ runner.temp }}/axern.rb
@@ -114,7 +114,7 @@ jobs:
           ref: ${{ github.sha }}
           path: publisher
       - name: Download immutable formula
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: homebrew-formula
           path: dist/homebrew

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
           tar -xzf "${archive}" -C "${RUNNER_TEMP}" syft
           printf '%s\n' "${RUNNER_TEMP}" >> "${GITHUB_PATH}"
       - name: Download local image lock
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: local-image-lock
           path: dist/local-image-lock
@@ -66,7 +66,7 @@ jobs:
           AXERN_LOCAL_IMAGE_LOCK_FILE: ${{ github.workspace }}/dist/local-image-lock/images.lock
         run: make release-build
       - name: Upload release artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-artifacts
           path: dist/release/*
@@ -102,7 +102,7 @@ jobs:
       - name: Build and verify SDK artifacts
         run: make sdk-artifact-verify
       - name: Upload SDK artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sdk-artifacts
           path: |
@@ -141,7 +141,7 @@ jobs:
       - name: Expose GitHub Actions cache runtime
         uses: crazy-max/ghaction-github-runtime@04d248b84655b509d8c44dc1d6f990c879747487 # v4.0.0
       - name: Log in to GHCR
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -161,7 +161,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       - name: Log in to GHCR
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -171,7 +171,7 @@ jobs:
           AXERN_RELEASE_VERSION: ${{ github.ref_type == 'tag' && github.ref_name || format('candidate-{0}', github.sha) }}
         run: bash scripts/release/build-local-image-lock.sh dist/local-image-lock/images.lock
       - name: Upload local image lock
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: local-image-lock
           path: dist/local-image-lock/images.lock
@@ -208,17 +208,17 @@ jobs:
       - name: Install kind
         run: go install sigs.k8s.io/kind@v0.30.0
       - name: Download release artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-artifacts
           path: dist/release
       - name: Download local image lock
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: local-image-lock
           path: dist/local-image-lock
       - name: Download SDK artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: sdk-artifacts
           path: dist/sdk
@@ -253,7 +253,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - name: Download release artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-artifacts
           path: dist/release
@@ -262,7 +262,7 @@ jobs:
           AXERN_RELEASE_DOWNLOAD_BASE: file://${{ github.workspace }}/dist/release
         run: bash scripts/release/install-cli.sh "${RUNNER_TEMP}/bin/axern"
       - name: Log in to GHCR
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -279,7 +279,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - name: Download release artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-artifacts
           path: dist/release
@@ -306,7 +306,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - name: Download SDK artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: sdk-artifacts
           path: dist/sdk
@@ -337,19 +337,19 @@ jobs:
           bash scripts/release/install-helm.sh "${RUNNER_TEMP}/bin/helm"
           echo "${RUNNER_TEMP}/bin" >> "${GITHUB_PATH}"
       - name: Download release artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-artifacts
           path: dist/release
       - name: Download local image lock
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: local-image-lock
           path: dist/local-image-lock
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       - name: Log in to GHCR
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -396,7 +396,7 @@ jobs:
           go-version: "1.25.12"
           cache: false
       - name: Download SDK artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: sdk-artifacts
           path: dist/sdk

--- a/scripts/release/image-build-contract-check.sh
+++ b/scripts/release/image-build-contract-check.sh
@@ -87,7 +87,7 @@ for contract in (
     "docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0",
     "crazy-max/ghaction-github-runtime@04d248b84655b509d8c44dc1d6f990c879747487 # v4.0.0",
     "packages: write",
-    "docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3",
+    "docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0",
     'build-and-push-images.sh "${{ matrix.arch }}"',
     "image-lock:",
     "build-local-image-lock.sh dist/local-image-lock/images.lock",


### PR DESCRIPTION
## Summary

- upgrade `actions/upload-artifact` to v7.0.1 and `actions/download-artifact` to v8.0.1
- upgrade `docker/login-action` to v4.6.0
- keep all actions pinned to immutable commit SHAs and update the release image contract

## Why

GitHub now warns that the previous artifact and registry login actions target Node.js 20 and temporarily forces them to run on Node.js 24. Updating to the current Node.js 24-native releases removes that compatibility dependency. `download-artifact` v8 also fails closed on artifact digest mismatches, which strengthens Axern release integrity.

## Validation

- scanned every directly referenced workflow action and confirmed its runtime is Node.js 24 or composite
- `actionlint .github/workflows/*.yml`
- `make release-check`
- `git diff --check`