### PR TITLE
fix(deps): resolve npm security alerts

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  fast-uri: 3.1.5
   protobufjs: 7.6.5
+  undici: 7.29.0
 
 importers:
 
@@ -1967,8 +1969,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -3060,8 +3062,8 @@ packages:
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unenv@2.0.0-rc.24:
@@ -4685,7 +4687,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -5375,7 +5377,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:
@@ -5734,7 +5736,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.2
-      undici: 7.28.0
+      undici: 7.29.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -6398,7 +6400,7 @@ snapshots:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.35.2
-      undici: 7.28.0
+      undici: 7.29.0
       workerd: 1.20260722.1
       ws: 8.21.0
       youch: 4.1.0-beta.10
@@ -7064,7 +7066,7 @@ snapshots:
 
   undici-types@7.19.2: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unenv@2.0.0-rc.24:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,4 +3,6 @@ packages:
   - "sdk/typescript"
 
 overrides:
+  fast-uri: 3.1.5
   protobufjs: 7.6.5
+  undici: 7.29.0


### PR DESCRIPTION
## Summary

- override `undici` to 7.29.0, resolving five advisories including one high-severity cache parsing issue
- override `fast-uri` to 3.1.5, resolving the high-severity host confusion advisory
- regenerate the pnpm lockfile without changing unrelated package versions

## Root cause

The documentation workspace receives `undici` through jsdom and Miniflare. jsdom accepts the patched release, but the current Wrangler/Miniflare chain pins vulnerable `undici` 7.28.0 exactly, including in the latest available Wrangler line. A workspace override is therefore required until upstream adopts 7.29.0. `fast-uri` is a transitive AJV dependency whose declared range already accepts 3.1.5.

## Security impact

Resolves Dependabot alerts #103 through #108:

- GHSA-7p8r-x3mc-p8w7 (`fast-uri`)
- GHSA-4cwx-7wf7-3272 (`undici`)
- GHSA-8xcm-r25x-g524 (`undici`)
- GHSA-v3r7-h72x-cjcm (`undici`)
- GHSA-jr45-8vmc-qm54 (`undici`)
- GHSA-m8rv-5g2x-5cg5 (`undici`)

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm audit --audit-level low` — no known vulnerabilities
- verified dependency paths resolve only `undici` 7.29.0 and `fast-uri` 3.1.5
- `make docs-check`
- `make docs-build`
- `make docs-verify`
- `make agent-doc-check`
- `git diff --check`