### PR TITLE
fix: synchronize interface warm-pool allocation

### DIFF
--- a/runtime/axnoded/internal/resources/interface_manager.go
+++ b/runtime/axnoded/internal/resources/interface_manager.go
@@ -36,7 +36,10 @@ type InterfaceManager struct {
 	quarantinedSlots atomic.Int64
 	buildMu          sync.Mutex
 	buildingSlots    int
-	buildChanged     chan struct{}
+	// buildGeneration advances after each warm-pool build so an allocator can
+	// observe a completion that races with its transition into waitForBuild.
+	buildGeneration uint64
+	buildChanged    chan struct{}
 
 	// store resource string.
 	db stateStore
@@ -129,12 +132,23 @@ func (m *InterfaceManager) endBuild() {
 		return
 	}
 	m.buildingSlots--
+	m.buildGeneration++
 	close(m.buildChanged)
 	m.buildChanged = make(chan struct{})
 }
 
-func (m *InterfaceManager) waitForBuild(ctx context.Context) error {
+func (m *InterfaceManager) currentBuildGeneration() uint64 {
 	m.buildMu.Lock()
+	defer m.buildMu.Unlock()
+	return m.buildGeneration
+}
+
+func (m *InterfaceManager) waitForBuild(ctx context.Context, observedGeneration uint64) error {
+	m.buildMu.Lock()
+	if m.buildGeneration != observedGeneration {
+		m.buildMu.Unlock()
+		return nil
+	}
 	if m.buildingSlots == 0 {
 		m.buildMu.Unlock()
 		return errord.ErrResourceExhausted

--- a/runtime/axnoded/internal/resources/interface_pool.go
+++ b/runtime/axnoded/internal/resources/interface_pool.go
@@ -111,6 +111,7 @@ func (m *InterfaceManager) Del(num int) {
 func (m *InterfaceManager) Allocate(opt AllocateOption) (Resource, error) {
 	m.initializeSlots()
 	for {
+		buildGeneration := m.currentBuildGeneration()
 		cacheStarted := time.Now()
 		if netResourceStr := m.interfaces.Pop(); netResourceStr != "" {
 			metrics.RecordResourceAllocateStage(string(InterfaceResourceName), "cache_pop", "hit", time.Since(cacheStarted).Seconds())
@@ -134,7 +135,7 @@ func (m *InterfaceManager) Allocate(opt AllocateOption) (Resource, error) {
 		}
 		if errors.Is(err, errord.ErrResourceExhausted) {
 			waitStarted := time.Now()
-			waitErr := m.waitForBuild(opt.Context)
+			waitErr := m.waitForBuild(opt.Context, buildGeneration)
 			waitResult := "ok"
 			if waitErr != nil {
 				waitResult = "error"

--- a/runtime/axnoded/internal/resources/warm_pool_test.go
+++ b/runtime/axnoded/internal/resources/warm_pool_test.go
@@ -533,27 +533,51 @@ func TestInterfaceManagerAllocateReturnsExhaustedWhenAtCapacity(t *testing.T) {
 
 func TestInterfaceManagerAllocateWaitsForInFlightPoolBuild(t *testing.T) {
 	manager := newBlockingInterfacePoolManager()
+	defer manager.releaseLookup()
 	buildDone := make(chan int, 1)
 	go func() {
 		buildDone <- manager.Add(1)
 	}()
 	<-manager.lookupStarted
 
+	waitContext := newWaitObservedContext(context.Background())
 	result := make(chan error, 1)
 	go func() {
-		_, err := manager.Allocate(AllocateOption{Context: context.Background()})
+		_, err := manager.Allocate(AllocateOption{Context: waitContext})
 		result <- err
 	}()
 
-	close(manager.continueLookup)
+	select {
+	case <-waitContext.waitObserved:
+	case err := <-result:
+		t.Fatalf("Allocate() returned before waiting for the in-flight build: %v", err)
+	}
+	manager.releaseLookup()
 	assert.Equal(t, 1, <-buildDone)
 	assert.NoError(t, <-result)
 	assert.Equal(t, 1, manager.UsingNum())
 	assert.Equal(t, int64(1), manager.activeSlots.Load())
 }
 
+func TestInterfaceManagerWaitForBuildObservesCompletedGeneration(t *testing.T) {
+	manager := newBlockingInterfacePoolManager()
+	defer manager.releaseLookup()
+
+	observedGeneration := manager.currentBuildGeneration()
+	buildDone := make(chan int, 1)
+	go func() {
+		buildDone <- manager.Add(1)
+	}()
+	<-manager.lookupStarted
+	manager.releaseLookup()
+	assert.Equal(t, 1, <-buildDone)
+
+	assert.NoError(t, manager.waitForBuild(context.Background(), observedGeneration))
+}
+
 func TestInterfaceManagerAllocateCancelsWhileWaitingForPoolBuild(t *testing.T) {
 	manager := newBlockingInterfacePoolManager()
+	defer manager.releaseLookup()
 	buildDone := make(chan int, 1)
 	go func() {
 		buildDone <- manager.Add(1)
@@ -565,14 +589,39 @@ func TestInterfaceManagerAllocateCancelsWhileWaitingForPoolBuild(t *testing.T) {
 	_, err := manager.Allocate(AllocateOption{Context: ctx})
 	assert.ErrorIs(t, err, context.Canceled)
 
-	close(manager.continueLookup)
+	manager.releaseLookup()
 	assert.Equal(t, 1, <-buildDone)
+}
+
+type waitObservedContext struct {
+	context.Context
+	waitObserved chan struct{}
+	once         sync.Once
+}
+
+func newWaitObservedContext(ctx context.Context) *waitObservedContext {
+	return &waitObservedContext{
+		Context:      ctx,
+		waitObserved: make(chan struct{}),
+	}
+}
+
+func (c *waitObservedContext) Done() <-chan struct{} {
+	// waitForBuild evaluates Done only after it has captured buildChanged. This
+	// signal lets the test release the builder without depending on scheduling.
+	c.once.Do(func() { close(c.waitObserved) })
+	return c.Context.Done()
 }
 
 type blockingInterfacePoolManager struct {
 	*InterfaceManager
 	lookupStarted  chan struct{}
 	continueLookup chan struct{}
+	releaseOnce    sync.Once
+}
+
+func (m *blockingInterfacePoolManager) releaseLookup() {
+	m.releaseOnce.Do(func() { close(m.continueLookup) })
 }
 
 func newBlockingInterfacePoolManager() *blockingInterfacePoolManager {


### PR DESCRIPTION
## Summary

- Make the interface warm-pool handoff lossless:
  - Record a completion generation for each warm-pool build.
  - Retry allocation when a build completes between the cache miss and waiter registration.
- Make the concurrency tests deterministic:
  - Observe the exact point at which allocation subscribes to the in-flight build.
  - Release the blocked builder through an idempotent test barrier.
  - Cover completion observed through the generation handoff.

## Root cause and impact

The previous test released the blocked pool builder immediately after starting the allocation goroutine, so scheduler ordering could let the build finish before the waiter subscribed. The same ordering exposed a production lost-wakeup window: a completed refill could leave a usable cached interface while allocation returned `resource exhausted`.

The new generation check preserves the existing capacity and cancellation contract without sleeps, polling, or blind retries. Cgroup warm-pool allocation remains unchanged because its create and allocate paths already share one serialization lock.

## Validation

- `go test ./internal/resources -run '^(TestInterfaceManagerAllocateWaitsForInFlightPoolBuild|TestInterfaceManagerWaitForBuildObservesCompletedGeneration|TestInterfaceManagerAllocateCancelsWhileWaitingForPoolBuild)$' -count=1000`
- `go test -race ./internal/resources`
- Linux: `go test -race ./internal/resources -run '^TestInterfaceManager' -count=100`
- `make fmt`
- `make vet`
- `make test-host`

Closes #49
