### PR TITLE
feat: expose asynchronous service deletion lifecycle

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -77,6 +77,7 @@ axern run --detach python:3.12-slim -- python -c 'print("later")'
 axern run logs --follow <run-id>
 axern service create --file service.yaml --wait
 axern service get <service-id>
+axern service delete <service-id> --wait
 axern function deploy --file function.yaml --wait
 axern function invocation list --namespace default <function-name>
 axern quota get --namespace default
@@ -100,6 +101,12 @@ axern identity whoami
 axern admin principal list
 axern admin role-binding list --namespace default
 ```
+
+Service deletion is asynchronous. `service delete` reports that deletion was
+requested; add `--wait` to wait for the persisted deletion phase to complete.
+The default `service list` view excludes deleted audit records; use
+`service list --status deleted` or exact `service get <service-id>` to inspect
+them until an administrator explicitly purges the record.
 
 `agent` requires an explicit `shell`, `run`, `connect`, `doctor`, `list`,
 `stop`, `workspace`, or `profile` subcommand. Agent workspaces keep one Service

--- a/apps/cli/internal/application/service/actions.go
+++ b/apps/cli/internal/application/service/actions.go
@@ -2,10 +2,17 @@ package service
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
 
 	servicev1 "github.com/cofy-x/axern/sdk/go/gen/axern/control/service/v1"
 	"google.golang.org/grpc"
 )
+
+const DefaultDeleteWaitTimeout = 5 * time.Minute
 
 type ActionClient interface {
 	DeleteService(context.Context, *servicev1.DeleteServiceRequest, ...grpc.CallOption) (*servicev1.DeleteServiceResponse, error)
@@ -14,6 +21,12 @@ type ActionClient interface {
 type DeleteResult struct {
 	ServiceID string
 	Service   *servicev1.Service
+}
+
+type DeleteParams struct {
+	ServiceID   string
+	Wait        bool
+	WaitTimeout time.Duration
 }
 
 func (c Control) ListServiceIDs(ctx context.Context, req *servicev1.ListServicesRequest) ([]string, error) {
@@ -27,7 +40,7 @@ func (c Control) ListServiceIDs(ctx context.Context, req *servicev1.ListServices
 func (c Control) DeleteServiceIDs(ctx context.Context, serviceIDs []string) ([]string, error) {
 	affectedIDs := make([]string, 0, len(serviceIDs))
 	for _, id := range serviceIDs {
-		result, err := c.DeleteService(ctx, id)
+		result, err := c.Delete(ctx, DeleteParams{ServiceID: id})
 		if err != nil {
 			return nil, err
 		}
@@ -36,27 +49,130 @@ func (c Control) DeleteServiceIDs(ctx context.Context, serviceIDs []string) ([]s
 	return affectedIDs, nil
 }
 
-func (c Control) DeleteService(ctx context.Context, serviceID string) (DeleteResult, error) {
-	return DeleteService(ctx, c.client, serviceID)
+func (c Control) Delete(ctx context.Context, params DeleteParams) (DeleteResult, error) {
+	params.ServiceID = strings.TrimSpace(params.ServiceID)
+	if params.ServiceID == "" {
+		return DeleteResult{}, fmt.Errorf("service id is required")
+	}
+	if params.WaitTimeout < 0 {
+		return DeleteResult{}, fmt.Errorf("service deletion wait timeout must not be negative")
+	}
+	if params.Wait && c.watcher == nil {
+		return DeleteResult{}, fmt.Errorf("service deletion watcher is required")
+	}
+	result, err := requestServiceDeletion(ctx, c.client, params.ServiceID)
+	if err != nil || !params.Wait || serviceDeletionComplete(result.Service) {
+		return result, err
+	}
+	service, waitErr := c.waitForDeletion(ctx, result.Service, params.WaitTimeout)
+	if service != nil {
+		result.Service = service
+		result.ServiceID = service.GetID()
+	}
+	return result, waitErr
 }
 
-func DeleteService(ctx context.Context, client ActionClient, serviceID string) (DeleteResult, error) {
+func requestServiceDeletion(ctx context.Context, client ActionClient, serviceID string) (DeleteResult, error) {
 	resp, err := client.DeleteService(ctx, &servicev1.DeleteServiceRequest{ServiceID: serviceID})
 	if err != nil {
 		return DeleteResult{}, err
 	}
-	deletedID := resp.GetService().GetID()
-	if deletedID == "" {
-		deletedID = serviceID
+	service := resp.GetService()
+	if err := validateDeletionSnapshot(serviceID, 0, service); err != nil {
+		return DeleteResult{}, fmt.Errorf("delete service response: %w", err)
 	}
-	return DeleteResult{ServiceID: deletedID, Service: resp.GetService()}, nil
+	return DeleteResult{ServiceID: service.GetID(), Service: service}, nil
 }
 
-func ResponseServiceID(responseID, fallbackID string) string {
-	if responseID != "" {
-		return responseID
+func (c Control) waitForDeletion(ctx context.Context, initial *servicev1.Service, timeout time.Duration) (*servicev1.Service, error) {
+	waitCtx := ctx
+	cancel := func() {}
+	if timeout > 0 {
+		waitCtx, cancel = context.WithTimeout(ctx, timeout)
 	}
-	return fallbackID
+	defer cancel()
+
+	last := initial
+	watch, err := c.watcher.WatchService(waitCtx, initial.GetID(), initial.GetVersion())
+	if err != nil {
+		return last, deletionWaitError(ctx, waitCtx, last, timeout, err)
+	}
+	defer watch.Close()
+	for {
+		next, recvErr := watch.Recv()
+		if recvErr != nil {
+			return last, deletionWaitError(ctx, waitCtx, last, timeout, recvErr)
+		}
+		if err := validateDeletionSnapshot(initial.GetID(), last.GetVersion(), next); err != nil {
+			return last, fmt.Errorf("watch service deletion: %w", err)
+		}
+		last = next
+		if serviceDeletionComplete(last) {
+			return last, nil
+		}
+	}
+}
+
+func validateDeletionSnapshot(serviceID string, afterVersion int64, service *servicev1.Service) error {
+	if service == nil {
+		return fmt.Errorf("response did not include a service")
+	}
+	if strings.TrimSpace(service.GetID()) == "" {
+		return fmt.Errorf("service id is empty")
+	}
+	if service.GetID() != serviceID {
+		return fmt.Errorf("service id %q does not match requested id %q", service.GetID(), serviceID)
+	}
+	if service.GetVersion() <= afterVersion {
+		return fmt.Errorf("service version %d is not newer than %d", service.GetVersion(), afterVersion)
+	}
+	deletion := service.GetDeletionStatus()
+	if deletion == nil {
+		return fmt.Errorf("service %q does not include deletion status", serviceID)
+	}
+	switch deletion.GetPhase() {
+	case servicev1.ServiceDeletionPhase_SERVICE_DELETION_PHASE_RELEASING_ALLOCATIONS,
+		servicev1.ServiceDeletionPhase_SERVICE_DELETION_PHASE_RECLAIMING_VOLUMES:
+		if service.GetStatus() != servicev1.ServiceStatus_SERVICE_STATUS_DELETING {
+			return fmt.Errorf("service %q deletion phase %s has status %s", serviceID, deletion.GetPhase(), service.GetStatus())
+		}
+	case servicev1.ServiceDeletionPhase_SERVICE_DELETION_PHASE_COMPLETE:
+		if service.GetStatus() != servicev1.ServiceStatus_SERVICE_STATUS_DELETED {
+			return fmt.Errorf("service %q completed deletion has status %s", serviceID, service.GetStatus())
+		}
+	default:
+		return fmt.Errorf("service %q has invalid deletion phase %s", serviceID, deletion.GetPhase())
+	}
+	return nil
+}
+
+func serviceDeletionComplete(service *servicev1.Service) bool {
+	return service.GetDeletionStatus().GetPhase() == servicev1.ServiceDeletionPhase_SERVICE_DELETION_PHASE_COMPLETE
+}
+
+func deletionWaitError(parentCtx, waitCtx context.Context, last *servicev1.Service, timeout time.Duration, err error) error {
+	if parentErr := parentCtx.Err(); parentErr != nil {
+		if errors.Is(parentErr, context.DeadlineExceeded) {
+			return fmt.Errorf(
+				"command deadline exceeded waiting for service %q deletion to complete (last phase %s); deletion continues in the background",
+				last.GetID(),
+				last.GetDeletionStatus().GetPhase(),
+			)
+		}
+		return parentErr
+	}
+	if errors.Is(waitCtx.Err(), context.DeadlineExceeded) {
+		return fmt.Errorf(
+			"timed out after %s waiting for service %q deletion to complete (last phase %s); deletion continues in the background",
+			timeout,
+			last.GetID(),
+			last.GetDeletionStatus().GetPhase(),
+		)
+	}
+	if errors.Is(err, io.EOF) {
+		return fmt.Errorf("watch service %q deletion ended before completion", last.GetID())
+	}
+	return fmt.Errorf("watch service %q deletion: %w", last.GetID(), err)
 }
 
 func ServiceIDs(services []*servicev1.Service) []string {

--- a/apps/cli/internal/application/service/actions_test.go
+++ b/apps/cli/internal/application/service/actions_test.go
@@ -2,24 +2,226 @@ package service
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
+	"time"
 
+	axernsdk "github.com/cofy-x/axern/sdk/go"
 	servicev1 "github.com/cofy-x/axern/sdk/go/gen/axern/control/service/v1"
 	"google.golang.org/grpc"
 )
 
-func TestDeleteServiceUsesResponseIdentity(t *testing.T) {
-	result, err := DeleteService(context.Background(), fakeServiceActionClient{}, "requested")
+func TestDeleteReturnsRequestedDeletionWithoutWatching(t *testing.T) {
+	client := &fakeServiceClient{deleteResponse: deleteResponse(deletingService(3, servicev1.ServiceDeletionPhase_SERVICE_DELETION_PHASE_RELEASING_ALLOCATIONS))}
+
+	result, err := New(client).Delete(context.Background(), DeleteParams{ServiceID: " svc-1 "})
 	if err != nil {
-		t.Fatalf("DeleteService() error = %v", err)
+		t.Fatalf("Delete() error = %v", err)
 	}
-	if result.ServiceID != "deleted" || result.Service.GetID() != "deleted" {
-		t.Fatalf("DeleteService() result = %+v", result)
+	if result.ServiceID != "svc-1" || result.Service.GetVersion() != 3 {
+		t.Fatalf("Delete() result = %+v", result)
+	}
+	if client.deleteRequest.GetServiceID() != "svc-1" {
+		t.Fatalf("DeleteService() id = %q, want normalized svc-1", client.deleteRequest.GetServiceID())
 	}
 }
 
-type fakeServiceActionClient struct{}
+func TestDeleteCompleteResponseDoesNotStartWatch(t *testing.T) {
+	client := &fakeServiceClient{deleteResponse: deleteResponse(deletingService(4, servicev1.ServiceDeletionPhase_SERVICE_DELETION_PHASE_COMPLETE))}
+	watcher := &fakeServiceWatcher{}
 
-func (fakeServiceActionClient) DeleteService(context.Context, *servicev1.DeleteServiceRequest, ...grpc.CallOption) (*servicev1.DeleteServiceResponse, error) {
-	return &servicev1.DeleteServiceResponse{Service: &servicev1.Service{ID: "deleted"}}, nil
+	result, err := NewWithWatcher(client, watcher).Delete(context.Background(), DeleteParams{ServiceID: "svc-1", Wait: true, WaitTimeout: time.Second})
+	if err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+	if !serviceDeletionComplete(result.Service) || watcher.calls != 0 {
+		t.Fatalf("Delete() result = %+v, watch calls = %d", result, watcher.calls)
+	}
+}
+
+func TestDeleteWaitsForAuthoritativeCompletionSnapshot(t *testing.T) {
+	client := &fakeServiceClient{
+		deleteResponse: deleteResponse(deletingService(7, servicev1.ServiceDeletionPhase_SERVICE_DELETION_PHASE_RELEASING_ALLOCATIONS)),
+	}
+	watcher := &fakeServiceWatcher{responses: []*servicev1.Service{
+		deletingService(9, servicev1.ServiceDeletionPhase_SERVICE_DELETION_PHASE_RECLAIMING_VOLUMES),
+		deletingService(12, servicev1.ServiceDeletionPhase_SERVICE_DELETION_PHASE_COMPLETE),
+	}}
+
+	result, err := NewWithWatcher(client, watcher).Delete(context.Background(), DeleteParams{ServiceID: "svc-1", Wait: true, WaitTimeout: time.Second})
+	if err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+	if result.Service.GetVersion() != 12 || !serviceDeletionComplete(result.Service) {
+		t.Fatalf("Delete() result = %+v, want completed version 12", result)
+	}
+	if watcher.calls != 1 || watcher.serviceID != "svc-1" || watcher.afterVersion != 7 {
+		t.Fatalf("WatchService() request = (%q, %d), calls = %d", watcher.serviceID, watcher.afterVersion, watcher.calls)
+	}
+	if !watcher.watch.closed {
+		t.Fatal("service deletion watch was not closed")
+	}
+	if client.replicaCalls != 0 || client.eventCalls != 0 || client.getCalls != 0 {
+		t.Fatalf("delete wait performed unrelated reads: get=%d replicas=%d events=%d", client.getCalls, client.replicaCalls, client.eventCalls)
+	}
+}
+
+func TestDeleteWaitTimeoutReturnsLastSnapshot(t *testing.T) {
+	initial := deletingService(5, servicev1.ServiceDeletionPhase_SERVICE_DELETION_PHASE_RELEASING_ALLOCATIONS)
+	client := &fakeServiceClient{deleteResponse: deleteResponse(initial)}
+	watcher := &fakeServiceWatcher{}
+
+	result, err := NewWithWatcher(client, watcher).Delete(context.Background(), DeleteParams{ServiceID: "svc-1", Wait: true, WaitTimeout: time.Nanosecond})
+	if err == nil || !strings.Contains(err.Error(), "deletion continues in the background") {
+		t.Fatalf("Delete() error = %v, want background deletion timeout", err)
+	}
+	if result.Service.GetVersion() != initial.GetVersion() {
+		t.Fatalf("Delete() last version = %d, want %d", result.Service.GetVersion(), initial.GetVersion())
+	}
+}
+
+func TestDeleteWaitHonorsParentCancellation(t *testing.T) {
+	client := &fakeServiceClient{deleteResponse: deleteResponse(deletingService(5, servicev1.ServiceDeletionPhase_SERVICE_DELETION_PHASE_RELEASING_ALLOCATIONS))}
+	watcher := &fakeServiceWatcher{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := NewWithWatcher(client, watcher).Delete(ctx, DeleteParams{ServiceID: "svc-1", Wait: true})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Delete() error = %v, want context canceled", err)
+	}
+}
+
+func TestDeleteWaitReportsParentDeadlineAsBackgroundDeletion(t *testing.T) {
+	client := &fakeServiceClient{deleteResponse: deleteResponse(deletingService(5, servicev1.ServiceDeletionPhase_SERVICE_DELETION_PHASE_RELEASING_ALLOCATIONS))}
+	watcher := &fakeServiceWatcher{}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
+	defer cancel()
+
+	result, err := NewWithWatcher(client, watcher).Delete(ctx, DeleteParams{ServiceID: "svc-1", Wait: true})
+	if err == nil || !strings.Contains(err.Error(), "command deadline exceeded") || !strings.Contains(err.Error(), "deletion continues in the background") {
+		t.Fatalf("Delete() error = %v, want command deadline background deletion error", err)
+	}
+	if result.Service.GetVersion() != 5 {
+		t.Fatalf("Delete() last version = %d, want 5", result.Service.GetVersion())
+	}
+}
+
+func TestDeleteRejectsMalformedAuthoritativeResponse(t *testing.T) {
+	tests := map[string]*servicev1.Service{
+		"missing service": nil,
+		"wrong id":        {ID: "svc-other", Version: 1, Status: servicev1.ServiceStatus_SERVICE_STATUS_DELETING, DeletionStatus: &servicev1.ServiceDeletionStatus{Phase: servicev1.ServiceDeletionPhase_SERVICE_DELETION_PHASE_RELEASING_ALLOCATIONS}},
+		"missing status":  {ID: "svc-1", Version: 1, Status: servicev1.ServiceStatus_SERVICE_STATUS_DELETING},
+		"invalid phase":   {ID: "svc-1", Version: 1, Status: servicev1.ServiceStatus_SERVICE_STATUS_DELETING, DeletionStatus: &servicev1.ServiceDeletionStatus{}},
+	}
+	for name, service := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := requestServiceDeletion(context.Background(), fakeServiceActionClient{response: deleteResponse(service)}, "svc-1")
+			if err == nil {
+				t.Fatal("requestServiceDeletion() error = nil")
+			}
+		})
+	}
+}
+
+func TestDeleteValidatesWaitBeforeRequestSideEffects(t *testing.T) {
+	tests := map[string]DeleteParams{
+		"missing watcher":  {ServiceID: "svc-1", Wait: true},
+		"negative timeout": {ServiceID: "svc-1", Wait: true, WaitTimeout: -time.Second},
+		"empty service id": {ServiceID: " ", Wait: false},
+	}
+	for name, params := range tests {
+		t.Run(name, func(t *testing.T) {
+			client := &fakeServiceClient{}
+			_, err := New(client).Delete(context.Background(), params)
+			if err == nil {
+				t.Fatal("Delete() error = nil")
+			}
+			if client.deleteCalls != 0 {
+				t.Fatalf("DeleteService() calls = %d, want 0", client.deleteCalls)
+			}
+		})
+	}
+}
+
+func TestDeleteRejectsNonMonotonicWatchSnapshot(t *testing.T) {
+	client := &fakeServiceClient{
+		deleteResponse: deleteResponse(deletingService(7, servicev1.ServiceDeletionPhase_SERVICE_DELETION_PHASE_RELEASING_ALLOCATIONS)),
+	}
+	watcher := &fakeServiceWatcher{responses: []*servicev1.Service{
+		deletingService(7, servicev1.ServiceDeletionPhase_SERVICE_DELETION_PHASE_RECLAIMING_VOLUMES),
+	}}
+
+	result, err := NewWithWatcher(client, watcher).Delete(context.Background(), DeleteParams{ServiceID: "svc-1", Wait: true, WaitTimeout: time.Second})
+	if err == nil || !strings.Contains(err.Error(), "not newer") {
+		t.Fatalf("Delete() error = %v, want non-monotonic snapshot rejection", err)
+	}
+	if result.Service.GetVersion() != 7 {
+		t.Fatalf("Delete() last version = %d, want 7", result.Service.GetVersion())
+	}
+}
+
+type fakeServiceWatcher struct {
+	calls        int
+	serviceID    string
+	afterVersion int64
+	responses    []*servicev1.Service
+	watch        *fakeServiceWatch
+}
+
+func (f *fakeServiceWatcher) WatchService(ctx context.Context, serviceID string, afterVersion int64) (axernsdk.ServiceWatch, error) {
+	f.calls++
+	f.serviceID = serviceID
+	f.afterVersion = afterVersion
+	f.watch = &fakeServiceWatch{ctx: ctx, responses: f.responses}
+	return f.watch, nil
+}
+
+type fakeServiceWatch struct {
+	ctx       context.Context
+	responses []*servicev1.Service
+	next      int
+	closed    bool
+}
+
+func (f *fakeServiceWatch) Recv() (*servicev1.Service, error) {
+	if f.next < len(f.responses) {
+		service := f.responses[f.next]
+		f.next++
+		return service, nil
+	}
+	<-f.ctx.Done()
+	return nil, f.ctx.Err()
+}
+
+func (f *fakeServiceWatch) Close() {
+	f.closed = true
+}
+
+type fakeServiceActionClient struct {
+	response *servicev1.DeleteServiceResponse
+}
+
+func (f fakeServiceActionClient) DeleteService(context.Context, *servicev1.DeleteServiceRequest, ...grpc.CallOption) (*servicev1.DeleteServiceResponse, error) {
+	return f.response, nil
+}
+
+func deleteResponse(service *servicev1.Service) *servicev1.DeleteServiceResponse {
+	return &servicev1.DeleteServiceResponse{Service: service}
+}
+
+func deletingService(version int64, phase servicev1.ServiceDeletionPhase) *servicev1.Service {
+	status := servicev1.ServiceStatus_SERVICE_STATUS_DELETING
+	if phase == servicev1.ServiceDeletionPhase_SERVICE_DELETION_PHASE_COMPLETE {
+		status = servicev1.ServiceStatus_SERVICE_STATUS_DELETED
+	}
+	return &servicev1.Service{
+		ID:      "svc-1",
+		Version: version,
+		Status:  status,
+		DeletionStatus: &servicev1.ServiceDeletionStatus{
+			Phase: phase,
+		},
+	}
 }

--- a/apps/cli/internal/application/service/client.go
+++ b/apps/cli/internal/application/service/client.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 
+	axernsdk "github.com/cofy-x/axern/sdk/go"
 	servicev1 "github.com/cofy-x/axern/sdk/go/gen/axern/control/service/v1"
 	"google.golang.org/grpc"
 )
@@ -17,11 +18,20 @@ type ServiceClient interface {
 	ListServiceEvents(context.Context, *servicev1.ListServiceEventsRequest, ...grpc.CallOption) (*servicev1.ListServiceEventsResponse, error)
 }
 
+type ServiceWatcher interface {
+	WatchService(context.Context, string, int64) (axernsdk.ServiceWatch, error)
+}
+
 type Control struct {
 	client       ServiceClient
+	watcher      ServiceWatcher
 	environments environmentResolver
 }
 
 func New(client ServiceClient) Control {
 	return Control{client: client}
+}
+
+func NewWithWatcher(client ServiceClient, watcher ServiceWatcher) Control {
+	return Control{client: client, watcher: watcher}
 }

--- a/apps/cli/internal/application/service/controller_test.go
+++ b/apps/cli/internal/application/service/controller_test.go
@@ -103,6 +103,9 @@ type fakeServiceClient struct {
 	replicaResponses []*servicev1.ListServiceReplicasResponse
 	eventCalls       int
 	eventResponses   []*servicev1.ListServiceEventsResponse
+	deleteCalls      int
+	deleteRequest    *servicev1.DeleteServiceRequest
+	deleteResponse   *servicev1.DeleteServiceResponse
 }
 
 func (f *fakeServiceClient) CreateService(_ context.Context, req *servicev1.CreateServiceRequest, _ ...grpc.CallOption) (*servicev1.CreateServiceResponse, error) {
@@ -130,7 +133,12 @@ func (f *fakeServiceClient) UpdateService(context.Context, *servicev1.UpdateServ
 	return &servicev1.UpdateServiceResponse{}, nil
 }
 
-func (f *fakeServiceClient) DeleteService(context.Context, *servicev1.DeleteServiceRequest, ...grpc.CallOption) (*servicev1.DeleteServiceResponse, error) {
+func (f *fakeServiceClient) DeleteService(_ context.Context, req *servicev1.DeleteServiceRequest, _ ...grpc.CallOption) (*servicev1.DeleteServiceResponse, error) {
+	f.deleteCalls++
+	f.deleteRequest = req
+	if f.deleteResponse != nil {
+		return f.deleteResponse, nil
+	}
 	return &servicev1.DeleteServiceResponse{}, nil
 }
 

--- a/apps/cli/internal/commands/service/command.go
+++ b/apps/cli/internal/commands/service/command.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cofy-x/axern/apps/cli/internal/output"
 	"github.com/cofy-x/axern/apps/cli/internal/parse"
 	"github.com/cofy-x/axern/apps/cli/internal/resourcespec"
+	axernsdk "github.com/cofy-x/axern/sdk/go"
 	commonv1 "github.com/cofy-x/axern/sdk/go/gen/axern/control/common/v1"
 	environmentv1 "github.com/cofy-x/axern/sdk/go/gen/axern/control/environment/v1"
 	servicev1 "github.com/cofy-x/axern/sdk/go/gen/axern/control/service/v1"
@@ -302,26 +303,32 @@ func listCommand(runtime command.Runtime) *cobra.Command {
 	var namespace, cursor string
 	var statuses, labels []string
 	var pageSize int32
-	cmd := &cobra.Command{Use: "list", Short: "List services", Args: command.NoArgs, RunE: func(cmd *cobra.Command, _ []string) error {
-		parsed, err := parse.ServiceStatuses(statuses)
-		if err != nil {
-			return command.Usage(err)
-		}
-		s, err := runtime.Open(cmd.Context())
-		if err != nil {
-			return err
-		}
-		defer s.Close()
-		resp, err := appservice.New(s.Clients.Service).List(s.Context, &servicev1.ListServicesRequest{Filter: &servicev1.ServiceListFilter{Namespace: namespace, Statuses: parsed, Labels: parse.Labels(labels), Cursor: cursor, PageSize: pageSize}})
-		if err != nil {
-			return err
-		}
-		if runtime.Options.Output == "json" {
-			return output.PrintServiceListJSON(cmd.OutOrStdout(), resp)
-		}
-		output.RenderServiceTable(cmd.OutOrStdout(), resp.GetServices(), output.ServiceListTableOptions{})
-		return nil
-	}}
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List services",
+		Long:  "List services. The default view excludes terminal deleted records; use --status deleted to retrieve deletion audit records.",
+		Args:  command.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			parsed, err := parse.ServiceStatuses(statuses)
+			if err != nil {
+				return command.Usage(err)
+			}
+			s, err := runtime.Open(cmd.Context())
+			if err != nil {
+				return err
+			}
+			defer s.Close()
+			resp, err := appservice.New(s.Clients.Service).List(s.Context, &servicev1.ListServicesRequest{Filter: &servicev1.ServiceListFilter{Namespace: namespace, Statuses: parsed, Labels: parse.Labels(labels), Cursor: cursor, PageSize: pageSize}})
+			if err != nil {
+				return err
+			}
+			if runtime.Options.Output == "json" {
+				return output.PrintServiceListJSON(cmd.OutOrStdout(), resp)
+			}
+			output.RenderServiceTable(cmd.OutOrStdout(), resp.GetServices(), output.ServiceListTableOptions{})
+			return nil
+		},
+	}
 	f := cmd.Flags()
 	f.StringVar(&namespace, "namespace", "", "namespace filter")
 	f.StringArrayVar(&statuses, "status", nil, "status filter; may be repeated")
@@ -536,22 +543,51 @@ func anyFlagChanged(cmd *cobra.Command, names ...string) bool {
 }
 
 func deleteCommand(runtime command.Runtime) *cobra.Command {
-	return &cobra.Command{Use: "delete <service-id>", Short: "Delete a service", Args: command.ExactArgs(1), RunE: func(cmd *cobra.Command, args []string) error {
+	var wait bool
+	var waitTimeout time.Duration
+	cmd := &cobra.Command{Use: "delete <service-id>", Short: "Request asynchronous service deletion", Args: command.ExactArgs(1), RunE: func(cmd *cobra.Command, args []string) error {
+		if cmd.Flags().Changed("wait-timeout") && !wait {
+			return command.Usage(fmt.Errorf("--wait-timeout requires --wait"))
+		}
+		if waitTimeout < 0 {
+			return command.Usage(fmt.Errorf("--wait-timeout must not be negative"))
+		}
 		s, err := runtime.Open(cmd.Context())
 		if err != nil {
 			return err
 		}
 		defer s.Close()
-		result, err := appservice.New(s.Clients.Service).DeleteService(s.Context, args[0])
-		if err != nil {
-			return err
+		control := appservice.New(s.Clients.Service)
+		if wait {
+			watcher, err := axernsdk.NewClient(s.Context, s.Conn.Target(), axernsdk.WithControlConn(s.Conn))
+			if err != nil {
+				return fmt.Errorf("open service deletion watcher: %w", err)
+			}
+			defer watcher.Close()
+			control = appservice.NewWithWatcher(s.Clients.Service, watcher)
 		}
-		if runtime.Options.Output == "json" {
-			return output.PrintServiceResponseJSON(cmd.OutOrStdout(), result.Service)
+		result, deleteErr := control.Delete(s.Context, appservice.DeleteParams{
+			ServiceID:   args[0],
+			Wait:        wait,
+			WaitTimeout: waitTimeout,
+		})
+		if result.Service != nil {
+			if runtime.Options.Output == "json" {
+				if err := output.PrintServiceResponseJSON(cmd.OutOrStdout(), result.Service); err != nil {
+					return err
+				}
+			} else {
+				output.RenderServiceDeletionResult(cmd.OutOrStdout(), result.Service)
+			}
 		}
-		fmt.Fprintf(cmd.OutOrStdout(), "Service deleted: %s\n", result.ServiceID)
+		if deleteErr != nil {
+			return deleteErr
+		}
 		return nil
 	}}
+	cmd.Flags().BoolVar(&wait, "wait", false, "wait for deletion to complete")
+	cmd.Flags().DurationVar(&waitTimeout, "wait-timeout", appservice.DefaultDeleteWaitTimeout, "deletion timeout; 0 disables it")
+	return cmd
 }
 
 func replicasCommand(runtime command.Runtime) *cobra.Command {

--- a/apps/cli/internal/commands/service/command_test.go
+++ b/apps/cli/internal/commands/service/command_test.go
@@ -1,9 +1,12 @@
 package service
 
 import (
+	"errors"
+	"strings"
 	"testing"
 	"time"
 
+	appservice "github.com/cofy-x/axern/apps/cli/internal/application/service"
 	"github.com/cofy-x/axern/apps/cli/internal/command"
 	commonv1 "github.com/cofy-x/axern/sdk/go/gen/axern/control/common/v1"
 	"google.golang.org/protobuf/proto"
@@ -16,6 +19,54 @@ func TestProbeBuildLeavesDefaultDurationsUnset(t *testing.T) {
 	}
 	if probe.GetInitialDelay() != nil || probe.GetPeriod() != nil || probe.GetTimeout() != nil {
 		t.Fatalf("default durations must remain unset: %+v", probe)
+	}
+}
+
+func TestDeleteCommandExposesBoundedWait(t *testing.T) {
+	cmd := deleteCommand(command.Runtime{})
+	if cmd.Flags().Lookup("wait") == nil || cmd.Flags().Lookup("wait-timeout") == nil {
+		t.Fatal("service delete is missing --wait or --wait-timeout")
+	}
+	waitTimeout, err := cmd.Flags().GetDuration("wait-timeout")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if waitTimeout != appservice.DefaultDeleteWaitTimeout {
+		t.Fatalf("--wait-timeout default = %s, want %s", waitTimeout, appservice.DefaultDeleteWaitTimeout)
+	}
+}
+
+func TestDeleteCommandRejectsTimeoutWithoutWait(t *testing.T) {
+	cmd := deleteCommand(command.Runtime{})
+	if err := cmd.Flags().Set("wait-timeout", "1s"); err != nil {
+		t.Fatal(err)
+	}
+	err := cmd.RunE(cmd, []string{"svc-1"})
+	var usageErr command.UsageError
+	if !errors.As(err, &usageErr) || !strings.Contains(err.Error(), "--wait-timeout requires --wait") {
+		t.Fatalf("delete command error = %v, want usage error", err)
+	}
+}
+
+func TestDeleteCommandRejectsNegativeWaitTimeout(t *testing.T) {
+	cmd := deleteCommand(command.Runtime{})
+	if err := cmd.Flags().Set("wait", "true"); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Flags().Set("wait-timeout", "-1s"); err != nil {
+		t.Fatal(err)
+	}
+	err := cmd.RunE(cmd, []string{"svc-1"})
+	var usageErr command.UsageError
+	if !errors.As(err, &usageErr) || !strings.Contains(err.Error(), "--wait-timeout must not be negative") {
+		t.Fatalf("delete command error = %v, want negative timeout usage error", err)
+	}
+}
+
+func TestListCommandDocumentsDeletedAuditView(t *testing.T) {
+	cmd := listCommand(command.Runtime{})
+	if !strings.Contains(cmd.Long, "--status deleted") || !strings.Contains(cmd.Long, "excludes terminal deleted records") {
+		t.Fatalf("service list long help = %q, want deleted audit guidance", cmd.Long)
 	}
 }
 

--- a/apps/cli/internal/output/common.go
+++ b/apps/cli/internal/output/common.go
@@ -66,6 +66,14 @@ func ServiceStatusLabel(status servicev1.ServiceStatus) string {
 	return trimEnumPrefix(status.String(), "SERVICE_STATUS_")
 }
 
+func ServiceDeletionPhaseLabel(phase servicev1.ServiceDeletionPhase) string {
+	return trimEnumPrefix(phase.String(), "SERVICE_DELETION_PHASE_")
+}
+
+func ServiceVolumeDispositionLabel(disposition servicev1.ServiceVolumeDisposition) string {
+	return trimEnumPrefix(disposition.String(), "SERVICE_VOLUME_DISPOSITION_")
+}
+
 func AllocationStatusLabel(status commonv1.AllocationStatus) string {
 	return trimEnumPrefix(status.String(), "ALLOCATION_STATUS_")
 }

--- a/apps/cli/internal/output/service.go
+++ b/apps/cli/internal/output/service.go
@@ -3,6 +3,7 @@ package output
 import (
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/cofy-x/axern/apps/cli/internal/workloaddiagnostic"
 	commonv1 "github.com/cofy-x/axern/sdk/go/gen/axern/control/common/v1"
@@ -17,6 +18,18 @@ func RenderServiceDescribe(w io.Writer, service *servicev1.Service, latestEvent 
 	renderServiceDetails(w, service, latestEvent, true)
 }
 
+func RenderServiceDeletionResult(w io.Writer, service *servicev1.Service) {
+	if service == nil {
+		return
+	}
+	phase := service.GetDeletionStatus().GetPhase()
+	if phase == servicev1.ServiceDeletionPhase_SERVICE_DELETION_PHASE_COMPLETE {
+		fmt.Fprintf(w, "Service deleted: %s\n", service.GetID())
+		return
+	}
+	fmt.Fprintf(w, "Service deletion requested: %s (phase=%s)\n", service.GetID(), ServiceDeletionPhaseLabel(phase))
+}
+
 func renderServiceDetails(w io.Writer, service *servicev1.Service, latestEvent *servicev1.ServiceEvent, includeDescribeFields bool) {
 	if service == nil {
 		return
@@ -25,6 +38,23 @@ func renderServiceDetails(w io.Writer, service *servicev1.Service, latestEvent *
 	fmt.Fprintf(w, "Namespace: %s\n", service.GetNamespace())
 	fmt.Fprintf(w, "Environment ID: %s\n", service.GetEnvironmentID())
 	fmt.Fprintf(w, "Status: %s\n", ServiceStatusLabel(service.GetStatus()))
+	if deletion := service.GetDeletionStatus(); deletion != nil {
+		fmt.Fprintf(
+			w,
+			"Deletion: phase=%s volume_disposition=%s\n",
+			ServiceDeletionPhaseLabel(deletion.GetPhase()),
+			ServiceVolumeDispositionLabel(deletion.GetVolumeDisposition()),
+		)
+		if claimIDs := deletion.GetClaimIds(); len(claimIDs) > 0 {
+			fmt.Fprintf(w, "Deletion Claims: %s\n", strings.Join(claimIDs, ","))
+		}
+		if completedAt := FormatProtoTimestamp(deletion.GetCompletedAt()); completedAt != "" {
+			fmt.Fprintf(w, "Deletion Completed At: %s\n", completedAt)
+		}
+		if message := deletion.GetMessage(); message != "" {
+			fmt.Fprintf(w, "Deletion Message: %s\n", message)
+		}
+	}
 	fmt.Fprintf(w, "Replicas: desired=%d ready=%d unhealthy=%d\n", service.GetReplicas(), service.GetReadyReplicas(), service.GetUnhealthyReplicas())
 	if includeDescribeFields {
 		fmt.Fprintf(w, "Labels: %s\n", formatLabels(service.GetLabels()))

--- a/apps/cli/internal/output/service_json.go
+++ b/apps/cli/internal/output/service_json.go
@@ -32,6 +32,7 @@ type ServiceJSON struct {
 	RolloutPolicy     *ServiceRolloutPolicyJSON     `json:"rollout_policy,omitempty"`
 	RolloutStatus     *ServiceRolloutStatusJSON     `json:"rollout_status,omitempty"`
 	Status            string                        `json:"status"`
+	DeletionStatus    *ServiceDeletionStatusJSON    `json:"deletion_status,omitempty"`
 	Config            *ExecutionConfigJSON          `json:"config,omitempty"`
 	AllocationIDs     []string                      `json:"allocation_ids,omitempty"`
 	Labels            map[string]string             `json:"labels,omitempty"`
@@ -45,6 +46,14 @@ type ServiceJSON struct {
 	LivenessProbe     *ServiceProbeJSON             `json:"liveness_probe"`
 	AutoscalingPolicy *ServiceAutoscalingPolicyJSON `json:"autoscaling_policy,omitempty"`
 	AutoscalingStatus *ServiceAutoscalingStatusJSON `json:"autoscaling_status,omitempty"`
+}
+
+type ServiceDeletionStatusJSON struct {
+	Phase             string   `json:"phase"`
+	VolumeDisposition string   `json:"volume_disposition"`
+	ClaimIDs          []string `json:"claim_ids,omitempty"`
+	Message           string   `json:"message,omitempty"`
+	CompletedAt       string   `json:"completed_at,omitempty"`
 }
 
 type ServiceRolloutPolicyJSON struct {
@@ -134,6 +143,7 @@ func NewServiceJSON(service *servicev1.Service) *ServiceJSON {
 		RolloutPolicy:     newServiceRolloutPolicyJSON(service.GetRolloutPolicy()),
 		RolloutStatus:     newServiceRolloutStatusJSON(service.GetRolloutStatus()),
 		Status:            ServiceStatusLabel(service.GetStatus()),
+		DeletionStatus:    newServiceDeletionStatusJSON(service.GetDeletionStatus()),
 		Config:            NewExecutionConfigJSON(service.GetConfig()),
 		AllocationIDs:     append([]string(nil), service.GetAllocationIds()...),
 		Labels:            cloneStringMap(service.GetLabels()),
@@ -147,6 +157,19 @@ func NewServiceJSON(service *servicev1.Service) *ServiceJSON {
 		LivenessProbe:     newServiceProbeJSON(service.GetLivenessProbe()),
 		AutoscalingPolicy: newServiceAutoscalingPolicyJSON(service.GetAutoscalingPolicy()),
 		AutoscalingStatus: newServiceAutoscalingStatusJSON(service.GetAutoscalingStatus()),
+	}
+}
+
+func newServiceDeletionStatusJSON(status *servicev1.ServiceDeletionStatus) *ServiceDeletionStatusJSON {
+	if status == nil {
+		return nil
+	}
+	return &ServiceDeletionStatusJSON{
+		Phase:             ServiceDeletionPhaseLabel(status.GetPhase()),
+		VolumeDisposition: ServiceVolumeDispositionLabel(status.GetVolumeDisposition()),
+		ClaimIDs:          append([]string(nil), status.GetClaimIds()...),
+		Message:           status.GetMessage(),
+		CompletedAt:       FormatProtoTimestamp(status.GetCompletedAt()),
 	}
 }
 

--- a/apps/cli/internal/output/service_json_test.go
+++ b/apps/cli/internal/output/service_json_test.go
@@ -173,6 +173,65 @@ func TestPrintServiceDescribeJSONUsesNullLatestEvent(t *testing.T) {
 	}
 }
 
+func TestPrintServiceResponseJSONIncludesDeletionStatus(t *testing.T) {
+	claimIDs := []string{"claim-a", "claim-b"}
+	service := &servicev1.Service{
+		ID:     "svc-deleting",
+		Status: servicev1.ServiceStatus_SERVICE_STATUS_DELETING,
+		DeletionStatus: &servicev1.ServiceDeletionStatus{
+			Phase:             servicev1.ServiceDeletionPhase_SERVICE_DELETION_PHASE_RECLAIMING_VOLUMES,
+			VolumeDisposition: servicev1.ServiceVolumeDisposition_SERVICE_VOLUME_DISPOSITION_DELETE,
+			ClaimIds:          claimIDs,
+			Message:           "waiting for volume cleanup",
+			CompletedAt:       timestamppb.New(time.Date(2026, time.August, 13, 8, 30, 0, 0, time.UTC)),
+		},
+	}
+	projected := NewServiceJSON(service)
+	claimIDs[0] = "mutated"
+	service.DeletionStatus.ClaimIds[1] = "also-mutated"
+	if projected.DeletionStatus.ClaimIDs[0] != "claim-a" || projected.DeletionStatus.ClaimIDs[1] != "claim-b" {
+		t.Fatalf("projected claim IDs = %#v, want defensive copy", projected.DeletionStatus.ClaimIDs)
+	}
+
+	var b strings.Builder
+	if err := PrintServiceResponseJSON(&b, service); err != nil {
+		t.Fatal(err)
+	}
+	var got struct {
+		Service struct {
+			DeletionStatus struct {
+				Phase             string   `json:"phase"`
+				VolumeDisposition string   `json:"volume_disposition"`
+				ClaimIDs          []string `json:"claim_ids"`
+				Message           string   `json:"message"`
+				CompletedAt       string   `json:"completed_at"`
+			} `json:"deletion_status"`
+		} `json:"service"`
+	}
+	if err := json.Unmarshal([]byte(b.String()), &got); err != nil {
+		t.Fatal(err)
+	}
+	deletion := got.Service.DeletionStatus
+	if deletion.Phase != "reclaiming-volumes" || deletion.VolumeDisposition != "delete" || deletion.Message != "waiting for volume cleanup" || deletion.CompletedAt != "2026-08-13T08:30:00Z" {
+		t.Fatalf("deletion_status = %#v, want stable deletion projection", deletion)
+	}
+	for _, unexpected := range []string{"SERVICE_DELETION_PHASE", "SERVICE_VOLUME_DISPOSITION"} {
+		if strings.Contains(b.String(), unexpected) {
+			t.Fatalf("service deletion JSON leaked protobuf enum %q: %s", unexpected, b.String())
+		}
+	}
+}
+
+func TestPrintServiceResponseJSONOmitsAbsentDeletionStatus(t *testing.T) {
+	var b strings.Builder
+	if err := PrintServiceResponseJSON(&b, &servicev1.Service{ID: "svc-active"}); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(b.String(), "deletion_status") {
+		t.Fatalf("active service JSON unexpectedly includes deletion_status: %s", b.String())
+	}
+}
+
 func TestPrintServiceResponseJSONIncludesAdmissionDiagnosticFields(t *testing.T) {
 	var b strings.Builder
 	err := PrintServiceResponseJSON(&b, &servicev1.Service{

--- a/apps/cli/internal/output/service_list_test.go
+++ b/apps/cli/internal/output/service_list_test.go
@@ -101,3 +101,17 @@ func TestRenderServiceTableWideWithLabelsIncludesOperationalColumns(t *testing.T
 		}
 	}
 }
+
+func TestRenderServiceTableDistinguishesDeletionLifecycle(t *testing.T) {
+	var b strings.Builder
+	RenderServiceTable(&b, []*servicev1.Service{
+		{ID: "svc-deleting", Status: servicev1.ServiceStatus_SERVICE_STATUS_DELETING},
+		{ID: "svc-deleted", Status: servicev1.ServiceStatus_SERVICE_STATUS_DELETED},
+	}, ServiceListTableOptions{})
+	out := b.String()
+	for _, want := range []string{"svc-deleting", "deleting", "svc-deleted", "deleted"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output %q does not contain %q", out, want)
+		}
+	}
+}

--- a/apps/cli/internal/output/service_test.go
+++ b/apps/cli/internal/output/service_test.go
@@ -249,6 +249,65 @@ func TestRenderServiceOmitsActionlessProbeAndEmptyAutoscalingPolicy(t *testing.T
 	}
 }
 
+func TestRenderServiceDescribeIncludesDeletionLifecycle(t *testing.T) {
+	var b strings.Builder
+	RenderServiceDescribe(&b, &servicev1.Service{
+		ID:     "svc-deleting",
+		Status: servicev1.ServiceStatus_SERVICE_STATUS_DELETING,
+		DeletionStatus: &servicev1.ServiceDeletionStatus{
+			Phase:             servicev1.ServiceDeletionPhase_SERVICE_DELETION_PHASE_RECLAIMING_VOLUMES,
+			VolumeDisposition: servicev1.ServiceVolumeDisposition_SERVICE_VOLUME_DISPOSITION_DELETE,
+			ClaimIds:          []string{"claim-a", "claim-b"},
+			Message:           "waiting for volume cleanup",
+			CompletedAt:       timestamppb.New(time.Date(2026, time.August, 13, 8, 30, 0, 0, time.UTC)),
+		},
+	}, nil)
+	out := b.String()
+	for _, want := range []string{
+		"Status: deleting",
+		"Deletion: phase=reclaiming-volumes volume_disposition=delete",
+		"Deletion Claims: claim-a,claim-b",
+		"Deletion Completed At: 2026-08-13T08:30:00Z",
+		"Deletion Message: waiting for volume cleanup",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output %q does not contain %q", out, want)
+		}
+	}
+}
+
+func TestRenderServiceDeletionResultDistinguishesRequestedAndComplete(t *testing.T) {
+	tests := []struct {
+		name    string
+		service *servicev1.Service
+		want    string
+	}{
+		{
+			name: "requested",
+			service: &servicev1.Service{ID: "svc-1", DeletionStatus: &servicev1.ServiceDeletionStatus{
+				Phase: servicev1.ServiceDeletionPhase_SERVICE_DELETION_PHASE_RELEASING_ALLOCATIONS,
+			}},
+			want: "Service deletion requested: svc-1 (phase=releasing-allocations)\n",
+		},
+		{
+			name: "complete",
+			service: &servicev1.Service{ID: "svc-1", DeletionStatus: &servicev1.ServiceDeletionStatus{
+				Phase: servicev1.ServiceDeletionPhase_SERVICE_DELETION_PHASE_COMPLETE,
+			}},
+			want: "Service deleted: svc-1\n",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var b strings.Builder
+			RenderServiceDeletionResult(&b, tc.service)
+			if got := b.String(); got != tc.want {
+				t.Fatalf("RenderServiceDeletionResult() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestFormatRelativeAge(t *testing.T) {
 	base := time.Date(2026, 4, 26, 12, 0, 0, 0, time.UTC)
 	cases := []struct {


### PR DESCRIPTION
## Summary

- Make asynchronous Service deletion explicit in the product CLI.
- Add a bounded `--wait` workflow based on persisted deletion phases rather than event-message parsing.
- Expose typed deletion status consistently in human-readable and JSON output.

## Why

The control plane already persists authoritative `ServiceDeletionStatus`, but the CLI previously reported every accepted delete request as completed and omitted that lifecycle state from JSON. This made automation infer completion from diagnostic events and made successful asynchronous deletion appear inconsistent across commands.

## Changes

- Deletion workflow
  - Report an accepted asynchronous request without claiming immediate completion.
  - Add `service delete --wait` and `--wait-timeout`.
  - Resume through authoritative Service watch snapshots until the persisted deletion phase is complete.
- Output contract
  - Project deletion phase, volume disposition, claim identifiers, message, and completion time into stable JSON.
  - Distinguish deleting and deletion-complete states in human-readable output.
- Discoverability
  - Document that the default Service list excludes terminal audit records.
  - Point users to `service list --status deleted` and exact `service get <id>`.

## Contract boundaries

- Keep Service deletion asynchronous.
- Keep terminal Services excluded from the default list.
- Keep exact Service lookup as the audit path until an explicit admin purge.
- Do not change public protobufs, controld persistence, or server-side deletion semantics.

## Validation

- `go test ./apps/cli/...`
- `go vet ./apps/cli/...`
- `make axern-cli-check-architecture`
- `test -z "$(gofmt -l apps/cli)"`
- `make axern-cli-build`
- `make agent-doc-check`
- `git diff --check origin/main...HEAD`

Closes #25
