### PR TITLE
fix: establish Claude Code dual-path mount contract

### DIFF
--- a/.x/runtime-stack.md
+++ b/.x/runtime-stack.md
@@ -99,6 +99,10 @@ direct OCI runtime exec is a debug-level tool.
   code.
 - Image-backed rootfs flows resolve through `axnoded -> imagemgr -> imagefsd`
   where needed.
+- Agent bundle image mounts remain single bind mounts. Claude Code is bound at
+  its private ABI target `/__claude_code`; axnoded's allocation-private rootfs
+  projection supplies the public `/opt/axern/agents/claude-code` symlink used by
+  Axrun. Both paths participate in mount conflict validation.
 - High-level process, file, PTY, and managed-proxy operations flow through
   sandboxd when supported. Axern tunnel sessions are a separate networking
   primitive.

--- a/apps/axrun/internal/agentbundle/bundle.go
+++ b/apps/axrun/internal/agentbundle/bundle.go
@@ -20,6 +20,10 @@ func MountTargetForSpec(spec domain.AgentSpec) string {
 	return MountTarget(spec.Name)
 }
 
+func ImageMountTargetForSpec(spec domain.AgentSpec) string {
+	return sharedagentbundle.ImageMountTarget(MountTargetForSpec(spec))
+}
+
 func BinDir(mountTarget string) string {
 	return sharedagentbundle.BinDir(mountTarget)
 }

--- a/apps/axrun/internal/backend/axern/adapter.go
+++ b/apps/axrun/internal/backend/axern/adapter.go
@@ -276,7 +276,7 @@ func agentBundleImageMount(spec domain.AgentSpec) axernsdk.ImageMount {
 	}
 	return axernsdk.ImageMount{
 		Image:    image,
-		Target:   agentbundle.MountTargetForSpec(spec),
+		Target:   agentbundle.ImageMountTargetForSpec(spec),
 		Readonly: true,
 	}
 }

--- a/apps/axrun/internal/backend/axern/agent_test.go
+++ b/apps/axrun/internal/backend/axern/agent_test.go
@@ -314,7 +314,7 @@ func TestAxernAdapterRuntimeForRequestMountsAgentImageBundleIntoTaskSandbox(t *t
 	}
 	mount := axernRuntime.Config.ImageMounts[0]
 	if mount.Image != "ghcr.io/cofy-x/claude-code-bundle:latest" ||
-		mount.Target != "/opt/axern/agents/claude-code" ||
+		mount.Target != "/__claude_code" ||
 		!mount.Readonly {
 		t.Fatalf("image mount = %#v", mount)
 	}

--- a/apps/cli/internal/application/agent/bundle.go
+++ b/apps/cli/internal/application/agent/bundle.go
@@ -17,6 +17,7 @@ type bundleRuntime struct {
 	Version     string
 	Image       string
 	MountTarget string
+	ImageTarget string
 	BinDir      string
 	Binary      string
 }
@@ -45,7 +46,8 @@ func resolveAgentBundle(ctx context.Context, catalog appcatalog.RuntimeCatalogCl
 	}
 	return bundleRuntime{
 		ID: id, Version: bundle.GetVersion(), Image: image, MountTarget: mountTarget,
-		BinDir: agentbundle.BinDir(mountTarget), Binary: binary,
+		ImageTarget: agentbundle.ImageMountTarget(mountTarget),
+		BinDir:      agentbundle.BinDir(mountTarget), Binary: binary,
 	}, nil
 }
 

--- a/apps/cli/internal/application/agent/workflow.go
+++ b/apps/cli/internal/application/agent/workflow.go
@@ -258,7 +258,7 @@ func workspaceExecutionConfig(workspace string, bundle bundleRuntime) *commonv1.
 	return &commonv1.ExecutionConfig{VolumeMounts: []*commonv1.ServiceVolumeMount{{
 		Name: workspaceVolumeName(workspace), Target: DefaultWorkspace, Options: []string{"rw", "nosuid", "nodev"},
 		ReclaimPolicy: storagev1.VolumeReclaimPolicy_VOLUME_RECLAIM_POLICY_DELETE,
-	}}, ImageMounts: []*commonv1.ImageMount{{Image: bundle.Image, Target: bundle.MountTarget, Readonly: true}}}
+	}}, ImageMounts: []*commonv1.ImageMount{{Image: bundle.Image, Target: firstNonEmpty(bundle.ImageTarget, bundle.MountTarget), Readonly: true}}}
 }
 
 type serviceUpdateBuilder func(*servicev1.Service) (*servicev1.UpdateServiceRequest, error)

--- a/apps/cli/internal/application/agent/workflow_test.go
+++ b/apps/cli/internal/application/agent/workflow_test.go
@@ -648,6 +648,20 @@ func (f *fakeCatalogClient) GetAgentBundle(context.Context, *catalogv1.GetAgentB
 	return &catalogv1.GetAgentBundleResponse{AgentBundle: bundle}, nil
 }
 
+func TestWorkspaceExecutionConfigUsesClaudeCodePrivateImageTarget(t *testing.T) {
+	bundle := bundleRuntime{
+		ID:          "claude-code",
+		Image:       "axern/claude-code-bundle:dev",
+		MountTarget: "/opt/axern/agents/claude-code",
+		ImageTarget: "/__claude_code",
+	}
+
+	mounts := workspaceExecutionConfig("project-a", bundle).GetImageMounts()
+	if len(mounts) != 1 || mounts[0].GetTarget() != "/__claude_code" || !mounts[0].GetReadonly() {
+		t.Fatalf("image mounts = %#v", mounts)
+	}
+}
+
 func fakeTemplate() *catalogv1.RuntimeTemplate {
 	return &catalogv1.RuntimeTemplate{
 		ID:      "coding-base",

--- a/control/controld/go.mod
+++ b/control/controld/go.mod
@@ -4,6 +4,8 @@ go 1.25.12
 
 replace github.com/cofy-x/axern/sdk/go => ../../sdk/go
 
+replace github.com/cofy-x/axern/lib/go/agentbundle => ../../lib/go/agentbundle
+
 replace github.com/cofy-x/axern/lib/go/nodecapability => ../../lib/go/nodecapability
 
 replace github.com/cofy-x/axern/lib/go/memorybudget => ../../lib/go/memorybudget
@@ -13,9 +15,10 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.30
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.29
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.105.2
+	github.com/cofy-x/axern/lib/go/agentbundle v0.0.0
 	github.com/cofy-x/axern/lib/go/imageref v0.0.0
-	github.com/cofy-x/axern/lib/go/nodecapability v0.0.0
 	github.com/cofy-x/axern/lib/go/memorybudget v0.0.0
+	github.com/cofy-x/axern/lib/go/nodecapability v0.0.0
 	github.com/cofy-x/axern/sdk/go v0.0.0
 	github.com/google/go-containerregistry v0.20.7
 	github.com/google/uuid v1.6.0

--- a/control/controld/go.sum
+++ b/control/controld/go.sum
@@ -77,7 +77,9 @@ github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFr
 github.com/klauspost/compress v1.18.6 h1:2jupLlAwFm95+YDR+NwD2MEfFO9d4z4Prjl1XXDjuao=
 github.com/klauspost/compress v1.18.6/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
@@ -90,6 +92,7 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
+github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=
 github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -136,9 +139,13 @@ go.opentelemetry.io/proto/otlp v1.10.0/go.mod h1:/CV4QoCR/S9yaPj8utp3lvQPoqMtxXd
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 golang.org/x/net v0.57.0 h1:K5+3DljvIuDG9/Jv9rvyMywYNFCQ9RSUY6OOTTkT+tE=
+golang.org/x/net v0.57.0/go.mod h1:KpXc8iv+r3XplLAG/f7Jsf9RPszJzdR0f58q9vGOuEU=
 golang.org/x/sync v0.22.0 h1:SZjpbeLmrCk4xhRSZFNZW5gFUeCeFgjekvI/+gfScek=
+golang.org/x/sync v0.22.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
+golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/text v0.40.0 h1:Ub2Z6/xjgF1WrYQz2nuITOEegKFtiIy+rieRJ5lHZKs=
+golang.org/x/text v0.40.0/go.mod h1:hpnzDAfGV753zIKo+wk3u1bVKCGPbrnF7+7LBF/UHVY=
 gonum.org/v1/gonum v0.17.0 h1:VbpOemQlsSMrYmn7T2OUvQ4dqxQXU+ouZFQsZOx50z4=
 gonum.org/v1/gonum v0.17.0/go.mod h1:El3tOrEuMpv2UdMrbNlKEh9vd86bmQ6vqIcDwxEOc1E=
 google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478 h1:yQugLulqltosq0B/f8l4w9VryjV+N/5gcW0jQ3N8Qec=
@@ -151,6 +158,7 @@ google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBN
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/control/controld/internal/api/publicv1/config_validation.go
+++ b/control/controld/internal/api/publicv1/config_validation.go
@@ -6,6 +6,7 @@ import (
 
 	executionkernel "github.com/cofy-x/axern/control/controld/internal/kernel/execution"
 	servicekernel "github.com/cofy-x/axern/control/controld/internal/kernel/service"
+	"github.com/cofy-x/axern/lib/go/agentbundle"
 	capabilitycontract "github.com/cofy-x/axern/lib/go/nodecapability"
 	commonv1 "github.com/cofy-x/axern/sdk/go/gen/axern/control/common/v1"
 	servicev1 "github.com/cofy-x/axern/sdk/go/gen/axern/control/service/v1"
@@ -101,8 +102,13 @@ func validateExecutionConfigImageMounts(config *commonv1.ExecutionConfig) error 
 			workspaceTarget = "/workspace"
 		}
 		for _, imageMount := range config.GetImageMounts() {
-			if imageMount != nil && pathsOverlap(workspaceTarget, imageMount.GetTarget()) {
-				return grpcstatus.Errorf(codes.InvalidArgument, "config.workspace_image target %q overlaps config.image_mounts target %q", workspaceTarget, imageMount.GetTarget())
+			if imageMount == nil {
+				continue
+			}
+			for _, imageTarget := range agentbundle.ClaimedMountTargets(path.Clean(strings.TrimSpace(imageMount.GetTarget()))) {
+				if pathsOverlap(workspaceTarget, imageTarget) {
+					return grpcstatus.Errorf(codes.InvalidArgument, "config.workspace_image target %q overlaps config.image_mounts target %q", workspaceTarget, imageTarget)
+				}
 			}
 		}
 		for _, volume := range config.GetVolumeMounts() {
@@ -136,12 +142,14 @@ func validateExecutionConfigImageMounts(config *commonv1.ExecutionConfig) error 
 		if protectedImageMountTarget(target) {
 			return grpcstatus.Errorf(codes.InvalidArgument, "config.image_mounts target %q is protected", target)
 		}
-		for existing := range seenTargets {
-			if pathsOverlap(existing, target) {
-				return grpcstatus.Errorf(codes.InvalidArgument, "config.image_mounts target %q overlaps target %q", target, existing)
+		for _, claimedTarget := range agentbundle.ClaimedMountTargets(target) {
+			for existing := range seenTargets {
+				if pathsOverlap(existing, claimedTarget) {
+					return grpcstatus.Errorf(codes.InvalidArgument, "config.image_mounts target %q overlaps target %q", claimedTarget, existing)
+				}
 			}
+			seenTargets[claimedTarget] = struct{}{}
 		}
-		seenTargets[target] = struct{}{}
 	}
 	if err := validateImageMountNoVolumeOverlap(config); err != nil {
 		return err
@@ -269,14 +277,15 @@ func validateImageMountNoVolumeOverlap(config *commonv1.ExecutionConfig) error {
 		if imageMount == nil {
 			continue
 		}
-		imageTarget := path.Clean(strings.TrimSpace(imageMount.GetTarget()))
-		for _, volume := range config.GetVolumeMounts() {
-			if volume == nil {
-				continue
-			}
-			volumeTarget := path.Clean(strings.TrimSpace(volume.GetTarget()))
-			if pathsOverlap(imageTarget, volumeTarget) {
-				return grpcstatus.Errorf(codes.InvalidArgument, "config.image_mounts target %q overlaps config.volume_mounts target %q", imageTarget, volumeTarget)
+		for _, imageTarget := range agentbundle.ClaimedMountTargets(path.Clean(strings.TrimSpace(imageMount.GetTarget()))) {
+			for _, volume := range config.GetVolumeMounts() {
+				if volume == nil {
+					continue
+				}
+				volumeTarget := path.Clean(strings.TrimSpace(volume.GetTarget()))
+				if pathsOverlap(imageTarget, volumeTarget) {
+					return grpcstatus.Errorf(codes.InvalidArgument, "config.image_mounts target %q overlaps config.volume_mounts target %q", imageTarget, volumeTarget)
+				}
 			}
 		}
 	}
@@ -288,14 +297,15 @@ func validateImageMountNoSecretFileOverlap(config *commonv1.ExecutionConfig) err
 		if imageMount == nil {
 			continue
 		}
-		imageTarget := path.Clean(strings.TrimSpace(imageMount.GetTarget()))
-		for _, secretFile := range config.GetSecretFiles() {
-			if secretFile == nil {
-				continue
-			}
-			secretPath := path.Clean(strings.TrimSpace(secretFile.GetPath()))
-			if pathsOverlap(imageTarget, secretPath) {
-				return grpcstatus.Errorf(codes.InvalidArgument, "config.image_mounts target %q overlaps config.secret_files path %q", imageTarget, secretPath)
+		for _, imageTarget := range agentbundle.ClaimedMountTargets(path.Clean(strings.TrimSpace(imageMount.GetTarget()))) {
+			for _, secretFile := range config.GetSecretFiles() {
+				if secretFile == nil {
+					continue
+				}
+				secretPath := path.Clean(strings.TrimSpace(secretFile.GetPath()))
+				if pathsOverlap(imageTarget, secretPath) {
+					return grpcstatus.Errorf(codes.InvalidArgument, "config.image_mounts target %q overlaps config.secret_files path %q", imageTarget, secretPath)
+				}
 			}
 		}
 	}

--- a/control/controld/internal/api/publicv1/config_validation_test.go
+++ b/control/controld/internal/api/publicv1/config_validation_test.go
@@ -172,6 +172,37 @@ func TestValidateExecutionConfigImageMounts(t *testing.T) {
 			}},
 		},
 		{
+			name: "Claude public alias overlaps image mount",
+			config: &commonv1.ExecutionConfig{ImageMounts: []*commonv1.ImageMount{
+				{Image: "claude", Target: "/__claude_code"},
+				{Image: "other", Target: "/opt/axern/agents/claude-code"},
+			}},
+		},
+		{
+			name: "Claude public alias overlaps workspace image",
+			config: &commonv1.ExecutionConfig{
+				WorkspaceImage: &commonv1.WorkspaceImageSource{
+					Variants:   []*commonv1.WorkspaceImageVariant{{Format: "oci", Image: "example.com/task@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}},
+					SourcePath: "tasks/task-a/workspace", Target: "/opt/axern/agents/claude-code/workspace",
+				},
+				ImageMounts: []*commonv1.ImageMount{{Image: "claude", Target: "/__claude_code"}},
+			},
+		},
+		{
+			name: "Claude public alias overlaps volume mount",
+			config: &commonv1.ExecutionConfig{
+				ImageMounts:  []*commonv1.ImageMount{{Image: "claude", Target: "/__claude_code"}},
+				VolumeMounts: []*commonv1.ServiceVolumeMount{{Name: "data", Target: "/opt/axern/agents/claude-code/data"}},
+			},
+		},
+		{
+			name: "Claude public alias overlaps secret file",
+			config: &commonv1.ExecutionConfig{
+				ImageMounts: []*commonv1.ImageMount{{Image: "claude", Target: "/__claude_code"}},
+				SecretFiles: []*commonv1.SecretFile{{Path: "/opt/axern/agents/claude-code/token", SecretID: "sec", Key: "token"}},
+			},
+		},
+		{
 			name: "overlapping volume mount",
 			config: &commonv1.ExecutionConfig{
 				ImageMounts: []*commonv1.ImageMount{{Image: "image", Target: "/opt/axern/tools"}},

--- a/deploy/images/lib/node-runtime-base.Dockerfile
+++ b/deploy/images/lib/node-runtime-base.Dockerfile
@@ -132,6 +132,7 @@ COPY runtime/axnoded/go.mod runtime/axnoded/go.sum /workspace/runtime/axnoded/
 COPY runtime/tunneld/go.mod runtime/tunneld/go.sum /workspace/runtime/tunneld/
 COPY runtime/volumed/go.mod runtime/volumed/go.sum /workspace/runtime/volumed/
 COPY network/bpfnet/go.mod /workspace/network/bpfnet/go.mod
+COPY lib/go/agentbundle/go.mod /workspace/lib/go/agentbundle/go.mod
 COPY lib/go/grpcclient/go.mod lib/go/grpcclient/go.sum /workspace/lib/go/grpcclient/
 COPY lib/go/imageref/go.mod /workspace/lib/go/imageref/go.mod
 COPY lib/go/llmproxy/go.mod /workspace/lib/go/llmproxy/go.mod
@@ -142,6 +143,7 @@ RUN cat > /workspace/go.work <<'EOF'
 go 1.25.12
 
 use (
+	./lib/go/agentbundle
 	./lib/go/grpcclient
 	./lib/go/imageref
 	./lib/go/llmproxy

--- a/lib/go/agentbundle/layout.go
+++ b/lib/go/agentbundle/layout.go
@@ -5,7 +5,11 @@ import (
 	"strings"
 )
 
-const MountRoot = "/opt/axern/agents"
+const (
+	MountRoot                = "/opt/axern/agents"
+	ClaudeCodeMountTarget    = MountRoot + "/claude-code"
+	ClaudeCodeABIMountTarget = "/__claude_code"
+)
 
 func MountTarget(agentName string) string {
 	name := sanitizeMountName(agentName)
@@ -13,6 +17,26 @@ func MountTarget(agentName string) string {
 		name = "agent"
 	}
 	return MountRoot + "/" + name
+}
+
+// ImageMountTarget returns the actual OCI bind mount target for a public agent
+// bundle path. Claude Code has a private short ABI path so its Bun executable
+// can name the mount-local loader without growing PT_INTERP.
+func ImageMountTarget(publicMountTarget string) string {
+	if strings.TrimSpace(publicMountTarget) == ClaudeCodeMountTarget {
+		return ClaudeCodeABIMountTarget
+	}
+	return strings.TrimSpace(publicMountTarget)
+}
+
+// ClaimedMountTargets returns every container path reserved by one image
+// mount. Claude Code's single private ABI mount also reserves its public alias.
+func ClaimedMountTargets(imageMountTarget string) []string {
+	target := strings.TrimSpace(imageMountTarget)
+	if target == ClaudeCodeABIMountTarget {
+		return []string{ClaudeCodeABIMountTarget, ClaudeCodeMountTarget}
+	}
+	return []string{target}
 }
 
 func BinDir(mountTarget string) string {

--- a/lib/go/agentbundle/layout_test.go
+++ b/lib/go/agentbundle/layout_test.go
@@ -13,10 +13,20 @@ func TestLayout(t *testing.T) {
 	if got := MountedBinary(target, "/bin/claude"); got != target+"/bin/claude" {
 		t.Fatalf("MountedBinary() = %q", got)
 	}
+	if got := ImageMountTarget(target); got != "/__claude_code" {
+		t.Fatalf("ImageMountTarget() = %q", got)
+	}
+	if got := ImageMountTarget("/opt/axern/agents/codex"); got != "/opt/axern/agents/codex" {
+		t.Fatalf("ImageMountTarget(codex) = %q", got)
+	}
+	claimed := ClaimedMountTargets(ClaudeCodeABIMountTarget)
+	if len(claimed) != 2 || claimed[0] != ClaudeCodeABIMountTarget || claimed[1] != ClaudeCodeMountTarget {
+		t.Fatalf("ClaimedMountTargets() = %#v", claimed)
+	}
 }
 
 func TestRejectsUnsafePaths(t *testing.T) {
-	for _, target := range []string{"/", "/opt/axern/agents", "/opt/axern/agents/../codex", "/opt/axern/agents/codex/bin"} {
+	for _, target := range []string{"/", "/__claude_code", "/__claude_code/bin", "/opt/axern/agents", "/opt/axern/agents/../codex", "/opt/axern/agents/codex/bin"} {
 		if ValidMountTarget(target) {
 			t.Errorf("ValidMountTarget(%q) = true", target)
 		}

--- a/runtime/axnoded/docker/runtimes/README.md
+++ b/runtime/axnoded/docker/runtimes/README.md
@@ -26,27 +26,32 @@ does not inherit the coding toolchain.
 Claude Code and Codex are published as self-contained Ubuntu 24.04 tool
 rootfs bundles, not runtime templates. The control-plane Agent Bundle Catalog
 selects their versioned image and absolute bundle binary path. A workload
-mounts the selected image read-only at its canonical
-`/opt/axern/agents/<agent>` path.
+mounts the selected image read-only at its canonical path. Claude Code uses
+`/__claude_code` so its native ELF can name the mount-local interpreter inside
+the fixed-size `PT_INTERP`; other bundles use `/opt/axern/agents/<agent>`.
 
 `claude-code-bundle` exposes `/bin/claude`. `codex-bundle` exposes `/bin/codex`.
 Each bundle carries its own loader, system libraries, CA certificates, and
 agent runtime; Codex additionally carries a pinned Node.js executable and npm
-package. The mounted commands resolve to
+package. The user-visible commands resolve to
 `/opt/axern/agents/claude-code/bin/claude` and
 `/opt/axern/agents/codex/bin/codex`.
 
-Each bundle context keeps three responsibilities separate: `Dockerfile`
-defines the pinned base, layers, arguments, and OCI labels; `build-bundle.sh`
-installs the agent, audits and classifies ELF files, and writes the manifest;
-the agent-named shell file is the minimal runtime wrapper. Build/audit logic
-must not be embedded back into a monolithic Dockerfile.
+Each bundle context keeps responsibilities separate: `Dockerfile` defines the
+pinned base, layers, arguments, and OCI labels; `build-bundle.sh` installs the
+agent, audits and classifies ELF files, and writes the manifest; focused patch
+helpers own any build-time binary transformation; the agent-named shell file is
+the minimal runtime wrapper. Build and audit logic must not be embedded back
+into a monolithic Dockerfile.
 
-Official bundle wrappers reject non-canonical mount targets and use the
-bundle's loader directly without exporting `LD_LIBRARY_PATH`. This keeps the
-agent ABI independent from glibc- and musl-based task images while preserving
-the task image's shell, Git, project toolchain, and test environment. Supported
-task images must still satisfy the Axrun shell contract, including `/bin/sh`.
+Official bundle wrappers reject non-canonical mount targets and never export
+`LD_LIBRARY_PATH`. Codex invokes its bundle loader directly. Claude Code instead
+executes its Bun standalone binary with an in-place `PT_INTERP` that selects the
+bundle loader, preserving `/proc/self/exe` across Bun self-restarts. Both models
+keep the agent ABI independent from glibc- and musl-based task images while
+preserving the task image's shell, Git, project toolchain, and test environment.
+Supported task images must still satisfy the Axrun shell contract, including
+`/bin/sh`.
 
 The task rootfs and bundle have separate responsibilities: `coding-base`
 supplies the coding workspace and shell, while a bundle supplies exactly one

--- a/runtime/axnoded/docker/runtimes/claude-code-bundle/Dockerfile
+++ b/runtime/axnoded/docker/runtimes/claude-code-bundle/Dockerfile
@@ -47,10 +47,11 @@ ARG UBUNTU_BASE_IMAGE
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
     apt-get update \
-    && apt-get install -y --no-install-recommends binutils ca-certificates curl file gnupg jq patchelf \
+    && apt-get install -y --no-install-recommends binutils ca-certificates curl file gnupg jq patchelf python3-minimal \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --chmod=0755 build-bundle.sh /usr/local/bin/build-claude-code-bundle
+COPY --chmod=0755 patch-bundle-elf.py /usr/local/bin/patch-claude-bundle-elf
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
     build-claude-code-bundle "${CLAUDE_CODE_VERSION}" "${TARGETARCH}" "${UBUNTU_BASE_IMAGE}"
@@ -61,15 +62,26 @@ ARG CLAUDE_CODE_VERSION=2.1.205
 ARG TARGETARCH
 ARG UBUNTU_BASE_IMAGE
 COPY --from=bundle_builder /opt/axern/agent-bundle /opt/axern/agent-bundle
+COPY --from=bundle_builder /tmp/claude-loader /l
 COPY --chmod=0755 claude /bin/claude
+
+RUN set -eux; \
+    case "${TARGETARCH}" in \
+      amd64) multiarch=x86_64-linux-gnu; lib_alias=glibc0; usr_lib_alias=glibc00000 ;; \
+      arm64) multiarch=aarch64-linux-gnu; lib_alias=glibc00; usr_lib_alias=glibc000000 ;; \
+      *) echo "unsupported architecture: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
+    ln -s "lib/${multiarch}" "/${lib_alias}"; \
+    ln -s "usr/lib/${multiarch}" "/${usr_lib_alias}"
 
 LABEL org.opencontainers.image.title="Axern Claude Code Self-contained Bundle" \
       org.opencontainers.image.description="Canonical self-contained Claude Code tool rootfs for read-only Axern image mounts." \
       org.opencontainers.image.source="https://github.com/cofy-x/axern" \
-      io.axern.agent-bundle.schema-version="1" \
+      io.axern.agent-bundle.schema-version="2" \
       io.axern.agent-bundle.agent-id="claude-code" \
       io.axern.agent-bundle.agent-version="${CLAUDE_CODE_VERSION}" \
       io.axern.agent-bundle.architecture="linux/${TARGETARCH}" \
-      io.axern.agent-bundle.mount-target="/opt/axern/agents/claude-code" \
+      io.axern.agent-bundle.mount-target="/__claude_code" \
+      io.axern.agent-bundle.public-mount-target="/opt/axern/agents/claude-code" \
       io.axern.agent-bundle.entrypoint="/bin/claude" \
       io.axern.agent-bundle.ubuntu-base-image="${UBUNTU_BASE_IMAGE}"

--- a/runtime/axnoded/docker/runtimes/claude-code-bundle/build-bundle.sh
+++ b/runtime/axnoded/docker/runtimes/claude-code-bundle/build-bundle.sh
@@ -4,18 +4,23 @@ set -eux
 claude_code_version="$1"
 target_arch="$2"
 ubuntu_base_image="$3"
-canonical_root=/opt/axern/agents/claude-code
+canonical_root=/__claude_code
+canonical_loader="$canonical_root/l"
 
 case "$target_arch" in
   amd64)
     loader=/lib64/ld-linux-x86-64.so.2
     multiarch=x86_64-linux-gnu
     elf_machine='Advanced Micro Devices X86-64'
+    lib_alias=glibc0
+    usr_lib_alias=glibc00000
     ;;
   arm64)
     loader=/lib/ld-linux-aarch64.so.1
     multiarch=aarch64-linux-gnu
     elf_machine=AArch64
+    lib_alias=glibc00
+    usr_lib_alias=glibc000000
     ;;
   *)
     echo "unsupported Claude Code bundle architecture: $target_arch" >&2
@@ -48,29 +53,41 @@ if printf '%s\n' "$ldd_output" | grep -Fq 'not found'; then
   exit 1
 fi
 
-install -d -m 0755 /opt/axern/agents
+size_before="$(stat -c %s /opt/axern/agent-bundle/bin/claude.real)"
+/usr/local/bin/patch-claude-bundle-elf bun /opt/axern/agent-bundle/bin/claude.real
+test "$(stat -c %s /opt/axern/agent-bundle/bin/claude.real)" = "$size_before"
+test "$(patchelf --print-interpreter /opt/axern/agent-bundle/bin/claude.real)" = "$canonical_loader"
+
+cp --dereference "$loader" /tmp/claude-loader
+/usr/local/bin/patch-claude-bundle-elf loader /tmp/claude-loader "$multiarch"
+chmod 0755 /tmp/claude-loader
+
 ln -s / "$canonical_root"
-library_path="$canonical_root/lib/$multiarch:$canonical_root/usr/lib/$multiarch:$canonical_root/lib:$canonical_root/usr/lib"
-loader_trace="$("$canonical_root$loader" --library-path "$library_path" --list /opt/axern/agent-bundle/bin/claude.real)"
-printf '%s\n' "$loader_trace" | awk -v root="$canonical_root" -v loader="$loader" '
+ln -s "lib/$multiarch" "/$lib_alias"
+ln -s "usr/lib/$multiarch" "/$usr_lib_alias"
+cp /tmp/claude-loader /l
+test "$(env -u LD_LIBRARY_PATH /opt/axern/agent-bundle/bin/claude.real --version)" = "$claude_code_version (Claude Code)"
+loader_trace="$(env -u LD_LIBRARY_PATH "$canonical_loader" --list /opt/axern/agent-bundle/bin/claude.real)"
+printf '%s\n' "$loader_trace" | awk -v root="$canonical_root" '
   {
     for (i = 1; i <= NF; i++)
-      if (substr($i, 1, 1) == "/" && (i == NF || $(i + 1) != "=>") && index($i, root) != 1 && $i != loader)
+      if (substr($i, 1, 1) == "/" && (i == NF || $(i + 1) != "=>") && index($i, root) != 1)
         exit 1
   }
 '
-rm "$canonical_root"
+rm "$canonical_root" "/$lib_alias" "/$usr_lib_alias" /l
 
 jq -n \
-  --arg schema_version "1" \
+  --arg schema_version "2" \
   --arg agent_id "claude-code" \
   --arg agent_version "$claude_code_version" \
   --arg architecture "linux/$target_arch" \
   --arg ubuntu_base_image "$ubuntu_base_image" \
   --arg canonical_mount_target "$canonical_root" \
+  --arg public_mount_target "/opt/axern/agents/claude-code" \
   --arg entrypoint "/bin/claude" \
-  --arg loader "$loader" \
+  --arg loader "/l" \
   --arg ca_bundle "/etc/ssl/certs/ca-certificates.crt" \
   --arg multiarch "$multiarch" \
-  '{schema_version: $schema_version, agent_id: $agent_id, agent_version: $agent_version, architecture: $architecture, ubuntu_base_image: $ubuntu_base_image, canonical_mount_target: $canonical_mount_target, entrypoint: $entrypoint, loader: $loader, ca_bundle: $ca_bundle, multiarch: $multiarch, node_version: null, elfs: ["/opt/axern/agent-bundle/bin/claude.real"], dynamic_executables: [], shared_objects: [], static_elfs: [], loader_wrapped_elfs: ["/opt/axern/agent-bundle/bin/claude.real"]}' \
+  '{schema_version: $schema_version, agent_id: $agent_id, agent_version: $agent_version, architecture: $architecture, ubuntu_base_image: $ubuntu_base_image, canonical_mount_target: $canonical_mount_target, public_mount_target: $public_mount_target, entrypoint: $entrypoint, loader: $loader, ca_bundle: $ca_bundle, multiarch: $multiarch, node_version: null, elfs: ["/opt/axern/agent-bundle/bin/claude.real"], dynamic_executables: ["/opt/axern/agent-bundle/bin/claude.real"], shared_objects: [], static_elfs: [], loader_wrapped_elfs: [], in_place_elfs: ["/opt/axern/agent-bundle/bin/claude.real"]}' \
   > /opt/axern/agent-bundle/manifest.json

--- a/runtime/axnoded/docker/runtimes/claude-code-bundle/claude
+++ b/runtime/axnoded/docker/runtimes/claude-code-bundle/claude
@@ -1,12 +1,13 @@
 #!/bin/sh
 set -eu
 
-root=/opt/axern/agents/claude-code
+root=/__claude_code
+public_root=/opt/axern/agents/claude-code
 manifest="$root/opt/axern/agent-bundle/manifest.json"
 real_binary="$root/opt/axern/agent-bundle/bin/claude.real"
 
-if [ "${AXRUN_AGENT_BUNDLE_MOUNT_TARGET:-$root}" != "$root" ]; then
-  echo "error: Claude Code bundle must be mounted at $root" >&2
+if [ "${AXRUN_AGENT_BUNDLE_MOUNT_TARGET:-$public_root}" != "$public_root" ]; then
+  echo "error: Claude Code public bundle entrypoint must be $public_root" >&2
   exit 126
 fi
 if [ ! -r "$manifest" ] || [ ! -x "$real_binary" ] || [ ! -r "$root/etc/ssl/certs/ca-certificates.crt" ]; then
@@ -14,23 +15,11 @@ if [ ! -r "$manifest" ] || [ ! -x "$real_binary" ] || [ ! -r "$root/etc/ssl/cert
   exit 126
 fi
 
-if [ -x "$root/lib64/ld-linux-x86-64.so.2" ]; then
-  loader="$root/lib64/ld-linux-x86-64.so.2"
-  multiarch=x86_64-linux-gnu
-elif [ -x "$root/lib/ld-linux-aarch64.so.1" ]; then
-  loader="$root/lib/ld-linux-aarch64.so.1"
-  multiarch=aarch64-linux-gnu
-else
-  echo "error: Claude Code bundle architecture loader is missing at $root" >&2
-  exit 126
-fi
-
-test -x "$loader" || {
-  echo "error: Claude Code bundle loader is missing at $loader" >&2
+test -x "$root/l" || {
+  echo "error: Claude Code bundle loader is missing at $root/l" >&2
   exit 126
 }
 
 unset LD_LIBRARY_PATH
 export SSL_CERT_FILE="$root/etc/ssl/certs/ca-certificates.crt"
-library_path="$root/lib/$multiarch:$root/usr/lib/$multiarch:$root/lib:$root/usr/lib"
-exec "$loader" --library-path "$library_path" "$real_binary" "$@"
+exec "$real_binary" "$@"

--- a/runtime/axnoded/docker/runtimes/claude-code-bundle/patch-bundle-elf.py
+++ b/runtime/axnoded/docker/runtimes/claude-code-bundle/patch-bundle-elf.py
@@ -1,0 +1,81 @@
+#!/usr/bin/python3
+import pathlib
+import struct
+import sys
+
+
+def patch_bun(path: pathlib.Path) -> None:
+    data = bytearray(path.read_bytes())
+    original = bytes(data)
+    old = {
+        b"/lib64/ld-linux-x86-64.so.2\0",
+        b"/lib/ld-linux-aarch64.so.1\0",
+    }
+    new = b"/__claude_code/l\0"
+
+    if data[:6] != b"\x7fELF\x02\x01":
+        raise SystemExit(f"expected a little-endian ELF64 file: {path}")
+
+    header_offset = struct.unpack_from("<Q", data, 32)[0]
+    header_size = struct.unpack_from("<H", data, 54)[0]
+    header_count = struct.unpack_from("<H", data, 56)[0]
+    if header_size != 56:
+        raise SystemExit(f"unexpected ELF64 program header size: {header_size}")
+
+    interpreters = []
+    for index in range(header_count):
+        offset = header_offset + index * header_size
+        if struct.unpack_from("<I", data, offset)[0] != 3:
+            continue
+        file_offset = struct.unpack_from("<Q", data, offset + 8)[0]
+        file_size = struct.unpack_from("<Q", data, offset + 32)[0]
+        interpreters.append((file_offset, file_size))
+
+    if len(interpreters) != 1:
+        raise SystemExit(f"expected one PT_INTERP in {path}, got {len(interpreters)}")
+    file_offset, file_size = interpreters[0]
+    current = bytes(data[file_offset : file_offset + file_size])
+    if current not in old:
+        raise SystemExit(f"unexpected PT_INTERP contents in {path}: {current!r}")
+    if len(new) > file_size:
+        raise SystemExit("replacement interpreter does not fit PT_INTERP")
+
+    data[file_offset : file_offset + file_size] = new.ljust(file_size, b"\0")
+    if len(data) != len(original):
+        raise SystemExit("in-place patch changed the Bun executable size")
+    if data[:file_offset] != original[:file_offset] or data[file_offset + file_size :] != original[file_offset + file_size :]:
+        raise SystemExit("in-place patch changed bytes outside PT_INTERP")
+    path.write_bytes(data)
+
+
+def patch_loader(path: pathlib.Path, multiarch: str) -> None:
+    data = path.read_bytes()
+    suffix = b"0" if multiarch == "aarch64-linux-gnu" else b""
+    replacements = (
+        (f"/usr/lib/{multiarch}/".encode(), b"/__claude_code/glibc00000" + suffix + b"/", 2),
+        (f"/lib/{multiarch}/".encode(), b"/__claude_code/glibc0" + suffix + b"/", 2),
+        (b"/etc/ld.so.cache", b"/__claude_code/c", 2),
+    )
+    for old, new, expected_count in replacements:
+        if len(old) != len(new):
+            raise SystemExit(f"loader replacement length mismatch: {old!r} -> {new!r}")
+        actual_count = data.count(old)
+        if actual_count != expected_count:
+            raise SystemExit(
+                f"unexpected loader string count for {old!r}: expected {expected_count}, got {actual_count}"
+            )
+        data = data.replace(old, new)
+    path.write_bytes(data)
+
+
+if len(sys.argv) not in (3, 4):
+    raise SystemExit(f"usage: {sys.argv[0]} bun <elf> | loader <elf> <multiarch>")
+
+mode = sys.argv[1]
+target = pathlib.Path(sys.argv[2])
+if mode == "bun" and len(sys.argv) == 3:
+    patch_bun(target)
+elif mode == "loader" and len(sys.argv) == 4:
+    patch_loader(target, sys.argv[3])
+else:
+    raise SystemExit(f"invalid arguments for mode {mode!r}")

--- a/runtime/axnoded/docs/image-mounts.md
+++ b/runtime/axnoded/docs/image-mounts.md
@@ -31,6 +31,8 @@ Validation rules:
   template, sandboxd-managed, or secret-file mounts;
 - missing directory targets are materialized in the final task rootfs view;
 - paths that cross rootfs symlinks are rejected;
+- runtime-managed bundle aliases must be absent from the task rootfs and must
+  not overlap any image, sandbox, volume, template, or secret-file mount;
 - setup failure fails allocation start, and allocation cleanup releases mounted
   image rootfs references.
 
@@ -45,10 +47,18 @@ only. Tool images should be relocatable bundles, for example:
 
 Axern does not merge operating-system ABIs. A generic tool bundle that relies
 on task libraries must document that dependency. Official Axern Claude Code and
-Codex bundles instead carry a complete, pinned Ubuntu ABI and invoke their own
+Codex bundles instead carry a complete, pinned Ubuntu ABI and select their own
 loader, so they support both glibc- and musl-based Axrun-compatible task images.
 The task image remains responsible for `/bin/sh`, project commands, and its own
 language and test toolchains.
+
+Claude Code has a dual-path contract backed by one mount. Its image rootfs is
+bound once at the private ABI path `/__claude_code`; the allocation-private
+rootfs projection creates `/opt/axern/agents/claude-code` as a symlink to that
+mount. The public path remains stable for agent discovery and `PATH`, while the
+short ABI path keeps the Bun executable's in-place `PT_INTERP` fixed at
+`/__claude_code/l`. Both paths are reserved together for overlap validation;
+Axern never bind-mounts the Claude image a second time at the public path.
 
 ## Runtime Ownership
 

--- a/runtime/axnoded/go.mod
+++ b/runtime/axnoded/go.mod
@@ -4,11 +4,14 @@ go 1.25.12
 
 replace github.com/cofy-x/axern/network/bpfnet => ../../network/bpfnet
 
+replace github.com/cofy-x/axern/lib/go/agentbundle => ../../lib/go/agentbundle
+
 replace github.com/cofy-x/axern/sdk/go => ../../sdk/go
 
 replace github.com/cofy-x/axern/lib/go/nodecapability => ../../lib/go/nodecapability
 
 require (
+	github.com/cofy-x/axern/lib/go/agentbundle v0.0.0
 	github.com/cofy-x/axern/lib/go/nodecapability v0.0.0
 	github.com/cofy-x/axern/network/bpfnet v0.0.0
 	github.com/cofy-x/axern/sdk/go v0.0.0

--- a/runtime/axnoded/go.sum
+++ b/runtime/axnoded/go.sum
@@ -118,12 +118,17 @@ go.opentelemetry.io/proto/otlp v1.10.0/go.mod h1:/CV4QoCR/S9yaPj8utp3lvQPoqMtxXd
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 golang.org/x/net v0.57.0 h1:K5+3DljvIuDG9/Jv9rvyMywYNFCQ9RSUY6OOTTkT+tE=
+golang.org/x/net v0.57.0/go.mod h1:KpXc8iv+r3XplLAG/f7Jsf9RPszJzdR0f58q9vGOuEU=
 golang.org/x/sync v0.22.0 h1:SZjpbeLmrCk4xhRSZFNZW5gFUeCeFgjekvI/+gfScek=
+golang.org/x/sync v0.22.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.0.0-20200217220822-9197077df867/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
+golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.45.0 h1:NwWyBmoJCbfTHpxrWoZ9C6/VxOf7ic219I8xZZFdrf0=
+golang.org/x/term v0.45.0/go.mod h1:9aqxs0blBcrm/n0L9QW0aRVD+ktan8ssZromtqJC43w=
 golang.org/x/text v0.40.0 h1:Ub2Z6/xjgF1WrYQz2nuITOEegKFtiIy+rieRJ5lHZKs=
+golang.org/x/text v0.40.0/go.mod h1:hpnzDAfGV753zIKo+wk3u1bVKCGPbrnF7+7LBF/UHVY=
 gonum.org/v1/gonum v0.17.0 h1:VbpOemQlsSMrYmn7T2OUvQ4dqxQXU+ouZFQsZOx50z4=
 gonum.org/v1/gonum v0.17.0/go.mod h1:El3tOrEuMpv2UdMrbNlKEh9vd86bmQ6vqIcDwxEOc1E=
 google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478 h1:yQugLulqltosq0B/f8l4w9VryjV+N/5gcW0jQ3N8Qec=

--- a/runtime/axnoded/internal/runtime/internal/rootfsflow/request.go
+++ b/runtime/axnoded/internal/runtime/internal/rootfsflow/request.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cofy-x/axern/lib/go/agentbundle"
 	"github.com/cofy-x/axern/runtime/axnoded/config"
 	"github.com/cofy-x/axern/runtime/axnoded/internal/runtime/contract"
 	runtimeoci "github.com/cofy-x/axern/runtime/axnoded/internal/runtime/oci"
@@ -42,6 +43,7 @@ func PrepareBundle(ctx context.Context, provider rootfsview.Provider, options co
 	}
 
 	targets := make([]rootfsview.MountTarget, 0, len(ociSpec.Mounts))
+	symlinks := make([]rootfsview.Symlink, 0, 1)
 	for _, mount := range ociSpec.Mounts {
 		if mount.Type != "bind" {
 			continue
@@ -59,12 +61,17 @@ func PrepareBundle(ctx context.Context, provider rootfsview.Provider, options co
 			return false, fmt.Errorf("bind mount source %q is neither a regular file nor a directory", mount.Source)
 		}
 		targets = append(targets, rootfsview.MountTarget{Destination: mount.Destination, Kind: kind})
+		if mount.Destination == agentbundle.ClaudeCodeABIMountTarget {
+			symlinks = append(symlinks, rootfsview.Symlink{
+				Path: agentbundle.ClaudeCodeMountTarget, Target: agentbundle.ClaudeCodeABIMountTarget,
+			})
+		}
 	}
 
 	prepareStart := time.Now()
 	view, err := provider.Prepare(ctx, options.ContainerID, rootfsview.Request{
 		RootDir: rootfsPath, Readonly: ociSpec.Root.Readonly, RuntimeName: policy.RuntimeName,
-		NeedsHostWritableRootfs: policy.NeedsHostWritableRootfs, ImmutableMount: policy.ImmutableMount, Targets: targets,
+		NeedsHostWritableRootfs: policy.NeedsHostWritableRootfs, ImmutableMount: policy.ImmutableMount, Targets: targets, Symlinks: symlinks,
 		EphemeralStorageLimitBytes: policy.EphemeralStorageLimitBytes, ProjectID: policy.ProjectID,
 	})
 	options.RecordStartupStep(contract.StartupPhaseRootfsPrepare, contract.StartupStepRootfsViewPrepare, time.Since(prepareStart))

--- a/runtime/axnoded/internal/runtime/internal/rootfsflow/request_test.go
+++ b/runtime/axnoded/internal/runtime/internal/rootfsflow/request_test.go
@@ -79,6 +79,26 @@ func TestPrepareBundleLeavesSpecWhenProjectionIsNotNeeded(t *testing.T) {
 	assert.Equal(t, rootfsPath, written.Root.Path)
 }
 
+func TestPrepareBundleModelsClaudeCodePublicSymlinkForSingleABIMount(t *testing.T) {
+	bundlePath := t.TempDir()
+	rootfsPath := t.TempDir()
+	imageSource := t.TempDir()
+	require.NoError(t, runtimeoci.WriteSpecAtomic(filepath.Join(bundlePath, config.ContainerSpecFile), &spec.Spec{
+		Root: &spec.Root{Path: rootfsPath, Readonly: true},
+		Mounts: []spec.Mount{{
+			Type: "bind", Source: imageSource, Destination: "/__claude_code", Options: []string{"rbind", "ro"},
+		}},
+	}))
+	provider := &providerStub{}
+
+	_, err := PrepareBundle(context.Background(), provider, contract.HandlerOptions{ContainerID: "alloc-claude"}, bundlePath, RuntimePolicy{RuntimeName: "runsc", ImmutableMount: testImmutableMount(rootfsPath)})
+
+	require.NoError(t, err)
+	require.Len(t, provider.request.Targets, 1)
+	assert.Equal(t, "/__claude_code", provider.request.Targets[0].Destination)
+	require.Equal(t, []rootfsview.Symlink{{Path: "/opt/axern/agents/claude-code", Target: "/__claude_code"}}, provider.request.Symlinks)
+}
+
 func TestPrepareBundleRejectsSpecialBindSource(t *testing.T) {
 	bundlePath := t.TempDir()
 	rootfsPath := t.TempDir()

--- a/runtime/axnoded/internal/runtime/rootfsview/provider.go
+++ b/runtime/axnoded/internal/runtime/rootfsview/provider.go
@@ -77,6 +77,11 @@ type MountTarget struct {
 	Kind        TargetKind
 }
 
+type Symlink struct {
+	Path   string `json:"path"`
+	Target string `json:"target"`
+}
+
 type RootfsBackingFacts struct {
 	EffectiveRoot       string                    `json:"effective_root"`
 	MountID             int                       `json:"mount_id"`
@@ -187,6 +192,7 @@ type Request struct {
 	NeedsHostWritableRootfs    bool
 	ImmutableMount             ImmutableMountDescriptor
 	Targets                    []MountTarget
+	Symlinks                   []Symlink
 	EphemeralStorageLimitBytes int64
 	ProjectID                  uint32
 }
@@ -235,7 +241,7 @@ func (p *overlayProvider) Prepare(_ context.Context, containerID string, request
 	if err != nil {
 		return View{}, err
 	}
-	if len(missing) == 0 && !request.NeedsHostWritableRootfs {
+	if len(missing) == 0 && len(request.Symlinks) == 0 && !request.NeedsHostWritableRootfs {
 		return View{}, nil
 	}
 	if p.filestoreDir == "" {
@@ -255,6 +261,10 @@ func (p *overlayProvider) Prepare(_ context.Context, containerID string, request
 		return View{}, err
 	}
 	if err := seedMountTargets(request.RootDir, view.UpperDir, missing); err != nil {
+		_ = cleanupOverlayView(filepath.Dir(view.MergedDir))
+		return View{}, err
+	}
+	if err := seedSymlinks(request.RootDir, view.UpperDir, request.Symlinks); err != nil {
 		_ = cleanupOverlayView(filepath.Dir(view.MergedDir))
 		return View{}, err
 	}
@@ -386,6 +396,37 @@ func seedMountTargets(lowerRoot, upperRoot string, targets []MountTarget) error 
 					return err
 				}
 			}
+		}
+	}
+	return nil
+}
+
+func seedSymlinks(lowerRoot, upperRoot string, symlinks []Symlink) error {
+	for _, symlink := range symlinks {
+		linkPath := strings.TrimSpace(symlink.Path)
+		target := strings.TrimSpace(symlink.Target)
+		if !path.IsAbs(linkPath) || path.Clean(linkPath) != linkPath || linkPath == "/" {
+			return fmt.Errorf("runtime symlink path %q must be a canonical absolute container path", symlink.Path)
+		}
+		if !path.IsAbs(target) || path.Clean(target) != target || target == "/" {
+			return fmt.Errorf("runtime symlink target %q must be a canonical absolute container path", symlink.Target)
+		}
+		parts := strings.Split(strings.TrimPrefix(linkPath, "/"), "/")
+		for index := 0; index < len(parts)-1; index++ {
+			relative := filepath.Join(parts[:index+1]...)
+			if err := createProjectionDirectory(filepath.Join(lowerRoot, relative), filepath.Join(upperRoot, relative)); err != nil {
+				return fmt.Errorf("seed runtime symlink parent %q: %w", linkPath, err)
+			}
+		}
+		lowerPath := filepath.Join(lowerRoot, filepath.Join(parts...))
+		if _, err := os.Lstat(lowerPath); err == nil {
+			return fmt.Errorf("runtime symlink path %q is already occupied in the task rootfs", linkPath)
+		} else if !os.IsNotExist(err) {
+			return fmt.Errorf("inspect runtime symlink path %q: %w", linkPath, err)
+		}
+		upperPath := filepath.Join(upperRoot, filepath.Join(parts...))
+		if err := os.Symlink(target, upperPath); err != nil {
+			return fmt.Errorf("create runtime symlink %q -> %q: %w", linkPath, target, err)
 		}
 	}
 	return nil
@@ -636,13 +677,14 @@ type projectionManifest struct {
 	HostWritable   bool                     `json:"host_writable"`
 	ImmutableMount ImmutableMountDescriptor `json:"immutable_mount"`
 	ProjectID      uint32                   `json:"project_id,omitempty"`
+	Symlinks       []Symlink                `json:"symlinks,omitempty"`
 }
 
 func writeProjectionManifest(root string, request Request) error {
 	content, err := json.Marshal(projectionManifest{
 		RuntimeName: request.RuntimeName, RootReadonly: request.Readonly,
 		HostWritable: request.NeedsHostWritableRootfs, ImmutableMount: request.ImmutableMount,
-		ProjectID: request.ProjectID,
+		ProjectID: request.ProjectID, Symlinks: request.Symlinks,
 	})
 	if err != nil {
 		return fmt.Errorf("marshal projection manifest: %w", err)

--- a/runtime/axnoded/internal/runtime/rootfsview/provider_test.go
+++ b/runtime/axnoded/internal/runtime/rootfsview/provider_test.go
@@ -164,6 +164,30 @@ func TestSeedMountTargetsCopiesExistingParentMetadata(t *testing.T) {
 	assert.True(t, leaf.Mode().IsRegular())
 }
 
+func TestSeedSymlinksCreatesPublicClaudeCodePathInProjection(t *testing.T) {
+	lower := t.TempDir()
+	upper := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(lower, "opt", "axern", "agents"), 0755))
+
+	require.NoError(t, seedSymlinks(lower, upper, []Symlink{{
+		Path: "/opt/axern/agents/claude-code", Target: "/__claude_code",
+	}}))
+	target, err := os.Readlink(filepath.Join(upper, "opt", "axern", "agents", "claude-code"))
+	require.NoError(t, err)
+	assert.Equal(t, "/__claude_code", target)
+}
+
+func TestSeedSymlinksRejectsOccupiedPublicPath(t *testing.T) {
+	lower := t.TempDir()
+	upper := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(lower, "opt", "axern", "agents", "claude-code"), 0755))
+
+	err := seedSymlinks(lower, upper, []Symlink{{
+		Path: "/opt/axern/agents/claude-code", Target: "/__claude_code",
+	}})
+	require.ErrorContains(t, err, "already occupied")
+}
+
 func TestReconcilePersistentViewsRemovesOnlyStaleRuntimeOwnedView(t *testing.T) {
 	filestore := t.TempDir()
 	provider := NewOverlayProvider(filestore).(*overlayProvider)

--- a/runtime/axnoded/internal/service/allocation/image_mounts.go
+++ b/runtime/axnoded/internal/service/allocation/image_mounts.go
@@ -5,6 +5,7 @@ import (
 	"path"
 	"strings"
 
+	"github.com/cofy-x/axern/lib/go/agentbundle"
 	runtime "github.com/cofy-x/axern/runtime/axnoded/internal/apipb/v1"
 	langrtmanager "github.com/cofy-x/axern/runtime/axnoded/internal/langruntime"
 	"github.com/cofy-x/axern/runtime/axnoded/internal/service/startplan"
@@ -100,21 +101,26 @@ func validateImageMountTargets(request *runtime.StartRequest) error {
 		if target == "." || !strings.HasPrefix(target, "/") || pathHasParentReference(rawTarget) {
 			return fmt.Errorf("image mount target %q must be an absolute container path below /: %w", rawTarget, errord.ErrInvalidArgument)
 		}
-		if _, protected := protectedImageMountTargets[target]; protected {
-			return fmt.Errorf("image mount target %q is protected: %w", target, errord.ErrInvalidArgument)
-		}
-		for existing := range seen {
-			if containerPathsOverlap(existing, target) {
-				return fmt.Errorf("image mount target %q overlaps image mount target %q: %w", target, existing, errord.ErrInvalidArgument)
+		claimedTargets := agentbundle.ClaimedMountTargets(target)
+		for _, claimedTarget := range claimedTargets {
+			if _, protected := protectedImageMountTargets[claimedTarget]; protected {
+				return fmt.Errorf("image mount target %q is protected: %w", claimedTarget, errord.ErrInvalidArgument)
+			}
+			for existing := range seen {
+				if containerPathsOverlap(existing, claimedTarget) {
+					return fmt.Errorf("image mount target %q overlaps image mount target %q: %w", claimedTarget, existing, errord.ErrInvalidArgument)
+				}
+			}
+			if err := validateImageMountTargetDoesNotOverlapMounts(claimedTarget, request.GetRuntimeTemplate().GetMounts()); err != nil {
+				return err
+			}
+			if err := validateImageMountTargetDoesNotOverlapMounts(claimedTarget, request.GetMounts()); err != nil {
+				return err
 			}
 		}
-		if err := validateImageMountTargetDoesNotOverlapMounts(target, request.GetRuntimeTemplate().GetMounts()); err != nil {
-			return err
+		for _, claimedTarget := range claimedTargets {
+			seen[claimedTarget] = struct{}{}
 		}
-		if err := validateImageMountTargetDoesNotOverlapMounts(target, request.GetMounts()); err != nil {
-			return err
-		}
-		seen[target] = struct{}{}
 	}
 	return nil
 }

--- a/runtime/axnoded/internal/service/allocation/image_mounts_test.go
+++ b/runtime/axnoded/internal/service/allocation/image_mounts_test.go
@@ -202,6 +202,20 @@ func TestValidateImageMountTargetsRejectsProtectedAndOverlappingTargets(t *testi
 				{Image: "image-b", Target: "/opt/axern/tools/codex"},
 			}},
 		},
+		{
+			name: "Claude public path overlaps sandbox mount",
+			request: &runtime.StartRequest{
+				ImageMounts: []*runtime.ImageMount{{Image: "claude", Target: "/__claude_code"}},
+				Mounts:      []*runtime.Mount{{Target: "/opt/axern/agents/claude-code/work"}},
+			},
+		},
+		{
+			name: "Claude public path overlaps another image mount",
+			request: &runtime.StartRequest{ImageMounts: []*runtime.ImageMount{
+				{Image: "claude", Target: "/__claude_code"},
+				{Image: "other", Target: "/opt/axern/agents/claude-code"},
+			}},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/runtime/axnoded/scripts/runtime/testdata/fake_anthropic_tool_server.py
+++ b/runtime/axnoded/scripts/runtime/testdata/fake_anthropic_tool_server.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+import json
+import os
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+
+COMMAND = r'''printf 'parent_exe='; readlink "/proc/$PPID/exe"; printf 'ld_library_path=%s\n' "${LD_LIBRARY_PATH-unset}"; find /testbed -name "*.php" | xargs grep -l "config.*install\|setup.*install\|upgrade\|patch" 2>/dev/null | head -20'''
+
+
+def frame(event, payload):
+    return f"event: {event}\ndata: {json.dumps(payload, separators=(',', ':'))}\n\n".encode()
+
+
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+    calls = 0
+
+    def do_POST(self):
+        length = int(self.headers.get("content-length", "0"))
+        request = json.loads(self.rfile.read(length) or b"{}")
+        Handler.calls += 1
+        if Handler.calls == 1:
+            content = [
+                frame("message_start", {"type": "message_start", "message": {"id": "msg_test", "type": "message", "role": "assistant", "model": request.get("model", "claude-test"), "content": [], "stop_reason": None, "stop_sequence": None, "usage": {"input_tokens": 1, "output_tokens": 1}}}),
+                frame("content_block_start", {"type": "content_block_start", "index": 0, "content_block": {"type": "tool_use", "id": "toolu_test", "name": "Bash", "input": {}}}),
+                frame("content_block_delta", {"type": "content_block_delta", "index": 0, "delta": {"type": "input_json_delta", "partial_json": json.dumps({"command": COMMAND}, separators=(",", ":"))}}),
+                frame("content_block_stop", {"type": "content_block_stop", "index": 0}),
+                frame("message_delta", {"type": "message_delta", "delta": {"stop_reason": "tool_use", "stop_sequence": None}, "usage": {"output_tokens": 1}}),
+                frame("message_stop", {"type": "message_stop"}),
+            ]
+        else:
+            content = [
+                frame("message_start", {"type": "message_start", "message": {"id": "msg_done", "type": "message", "role": "assistant", "model": request.get("model", "claude-test"), "content": [], "stop_reason": None, "stop_sequence": None, "usage": {"input_tokens": 1, "output_tokens": 1}}}),
+                frame("content_block_start", {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}}),
+                frame("content_block_delta", {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "tool call complete"}}),
+                frame("content_block_stop", {"type": "content_block_stop", "index": 0}),
+                frame("message_delta", {"type": "message_delta", "delta": {"stop_reason": "end_turn", "stop_sequence": None}, "usage": {"output_tokens": 1}}),
+                frame("message_stop", {"type": "message_stop"}),
+            ]
+        body = b"".join(content)
+        self.send_response(200)
+        self.send_header("content-type", "text/event-stream")
+        self.send_header("content-length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, _format, *_args):
+        pass
+
+
+if __name__ == "__main__":
+    server = ThreadingHTTPServer(("0.0.0.0", int(os.environ.get("PORT", "18090"))), Handler)
+    port_file = os.environ.get("PORT_FILE")
+    if port_file:
+        with open(port_file, "w", encoding="utf-8") as stream:
+            stream.write(str(server.server_port))
+    server.serve_forever()

--- a/runtime/axnoded/scripts/runtime/verify-agent-bundle-image.sh
+++ b/runtime/axnoded/scripts/runtime/verify-agent-bundle-image.sh
@@ -11,13 +11,23 @@ agent_id="$2"
 binary="$3"
 agent_version="$4"
 version_output="$5"
-mount_target="/opt/axern/agents/${agent_id}"
+case "${agent_id}" in
+  claude-code) mount_target=/__claude_code; public_mount_target=/opt/axern/agents/claude-code ;;
+  *) mount_target="/opt/axern/agents/${agent_id}" ;;
+esac
 extract_dir="$(mktemp -d "${TMPDIR:-/tmp}/axern-agent-bundle.XXXXXX")"
 negative_dir="$(mktemp -d "${TMPDIR:-/tmp}/axern-agent-bundle-negative.XXXXXX")"
 container_name="axern-agent-bundle-verify-${agent_id}-$$"
+proc_probe_container_name="axern-agent-bundle-proc-probe-${agent_id}-$$"
+fake_server_pid=""
 
 cleanup() {
   docker rm -f "${container_name}" >/dev/null 2>&1 || true
+  docker rm -f "${proc_probe_container_name}" >/dev/null 2>&1 || true
+  if [ -n "${fake_server_pid}" ]; then
+    kill "${fake_server_pid}" >/dev/null 2>&1 || true
+    wait "${fake_server_pid}" >/dev/null 2>&1 || true
+  fi
   rm -rf "${extract_dir}"
   rm -rf "${negative_dir}"
 }
@@ -26,12 +36,54 @@ trap cleanup EXIT
 docker image inspect "${image_ref}" >/dev/null
 image_arch="$(docker image inspect "${image_ref}" --format '{{.Architecture}}')"
 case "${image_arch}" in
-  amd64) loader_relative=lib64/ld-linux-x86-64.so.2; multiarch=x86_64-linux-gnu ;;
-  arm64) loader_relative=lib/ld-linux-aarch64.so.1; multiarch=aarch64-linux-gnu ;;
+  amd64) system_loader_relative=lib64/ld-linux-x86-64.so.2; multiarch=x86_64-linux-gnu ;;
+  arm64) system_loader_relative=lib/ld-linux-aarch64.so.1; multiarch=aarch64-linux-gnu ;;
   *) echo "unsupported bundle image architecture ${image_arch}" >&2; exit 1 ;;
 esac
+loader_relative="${system_loader_relative}"
+if [ "${agent_id}" = claude-code ]; then
+  loader_relative=l
+fi
 docker create --name "${container_name}" "${image_ref}" >/dev/null
 docker export "${container_name}" | tar -xf - -C "${extract_dir}"
+# mktemp creates the extraction root with mode 0700, while an OCI image root is
+# traversable. Preserve that rootfs contract so the non-root tool-call probe
+# exercises Claude itself instead of failing at the host bind-mount boundary.
+chmod 0755 "${extract_dir}"
+
+if [ "${agent_id}" = claude-code ]; then
+  python3 - "${extract_dir}/opt/axern/agent-bundle/bin/claude.real" \
+    "${extract_dir}/opt/axern/agent-bundle/manifest.json" <<'PY'
+import json
+import pathlib
+import struct
+import sys
+
+binary = pathlib.Path(sys.argv[1]).read_bytes()
+manifest = json.loads(pathlib.Path(sys.argv[2]).read_text())
+header_offset = struct.unpack_from("<Q", binary, 32)[0]
+header_size = struct.unpack_from("<H", binary, 54)[0]
+header_count = struct.unpack_from("<H", binary, 56)[0]
+interpreters = []
+for index in range(header_count):
+    offset = header_offset + index * header_size
+    if struct.unpack_from("<I", binary, offset)[0] == 3:
+        file_offset = struct.unpack_from("<Q", binary, offset + 8)[0]
+        file_size = struct.unpack_from("<Q", binary, offset + 32)[0]
+        interpreters.append(binary[file_offset : file_offset + file_size].rstrip(b"\0").decode())
+if interpreters != ["/__claude_code/l"]:
+    raise SystemExit(f"unexpected Claude PT_INTERP: {interpreters!r}")
+if manifest.get("loader_wrapped_elfs") != []:
+    raise SystemExit("Claude manifest still declares loader-wrapped executables")
+expected = ["/opt/axern/agent-bundle/bin/claude.real"]
+if manifest.get("dynamic_executables") != expected or manifest.get("in_place_elfs") != expected:
+    raise SystemExit("Claude manifest does not identify its in-place-patched executable")
+PY
+  if grep -F -- '--library-path' "${extract_dir}/bin/claude" >/dev/null; then
+    echo "Claude launcher still invokes the dynamic loader directly" >&2
+    exit 1
+  fi
+fi
 
 for base_image in ${AGENT_BUNDLE_VERIFY_BASE_IMAGES:-busybox:1.36 ubuntu:24.04}; do
   if ! docker image inspect "${base_image}" >/dev/null 2>&1; then
@@ -48,9 +100,16 @@ for base_image in ${AGENT_BUNDLE_VERIFY_BASE_IMAGES:-busybox:1.36 ubuntu:24.04};
     --env "BUNDLE_LOADER_RELATIVE=${loader_relative}" \
     --env "BUNDLE_MULTIARCH=${multiarch}" \
     --env "BUNDLE_VERSION_OUTPUT=${version_output}" \
-    --env "AXRUN_AGENT_BUNDLE_MOUNT_TARGET=${mount_target}" \
+    --env "AXRUN_AGENT_BUNDLE_MOUNT_TARGET=${public_mount_target:-${mount_target}}" \
     "${base_image}" /bin/sh -lc '
       set -eu
+      if [ "$BUNDLE_AGENT_ID" = claude-code ]; then
+        mkdir -p /opt/axern/agents
+        ln -s "$BUNDLE_MOUNT_TARGET" /opt/axern/agents/claude-code
+        BUNDLE_PUBLIC_MOUNT_TARGET=/opt/axern/agents/claude-code
+      else
+        BUNDLE_PUBLIC_MOUNT_TARGET="$BUNDLE_MOUNT_TARGET"
+      fi
       manifest="$BUNDLE_MOUNT_TARGET/opt/axern/agent-bundle/manifest.json"
       test -r "$manifest"
       grep -F "\"agent_id\": \"$BUNDLE_AGENT_ID\"" "$manifest"
@@ -58,8 +117,18 @@ for base_image in ${AGENT_BUNDLE_VERIFY_BASE_IMAGES:-busybox:1.36 ubuntu:24.04};
       grep -F "\"architecture\": \"$BUNDLE_ARCHITECTURE\"" "$manifest"
       grep -F "\"canonical_mount_target\": \"$BUNDLE_MOUNT_TARGET\"" "$manifest"
       LD_LIBRARY_PATH=/definitely-not-a-system-library \
-        "$BUNDLE_MOUNT_TARGET/bin/$BUNDLE_BINARY" --version > /tmp/agent-version.txt
+        "$BUNDLE_PUBLIC_MOUNT_TARGET/bin/$BUNDLE_BINARY" --version > /tmp/agent-version.txt
       grep -Fx "$BUNDLE_VERSION_OUTPUT" /tmp/agent-version.txt
+      if [ "$BUNDLE_AGENT_ID" = claude-code ]; then
+        set +e
+        "$BUNDLE_MOUNT_TARGET/opt/axern/agent-bundle/bin/claude.real" -S \
+          > /tmp/claude-self-restart.txt 2>&1
+        self_restart_status=$?
+        set -e
+        test "$self_restart_status" -ne 127
+        ! grep -E -- "-S: error while loading shared libraries|cannot open shared object file" \
+          /tmp/claude-self-restart.txt
+      fi
       loader="$BUNDLE_MOUNT_TARGET/$BUNDLE_LOADER_RELATIVE"
       library_path="$BUNDLE_MOUNT_TARGET/lib/$BUNDLE_MULTIARCH:$BUNDLE_MOUNT_TARGET/usr/lib/$BUNDLE_MULTIARCH:$BUNDLE_MOUNT_TARGET/lib:$BUNDLE_MOUNT_TARGET/usr/lib"
       case "$BUNDLE_AGENT_ID" in
@@ -94,7 +163,74 @@ for base_image in ${AGENT_BUNDLE_VERIFY_BASE_IMAGES:-busybox:1.36 ubuntu:24.04};
     "${agent_id}" "${base_image}" "${duration_seconds}"
 done
 
+if [ "${agent_id}" = claude-code ]; then
+  docker run -d -t --name "${proc_probe_container_name}" \
+    --volume "${extract_dir}:${mount_target}:ro" \
+    --env "AXRUN_AGENT_BUNDLE_MOUNT_TARGET=${public_mount_target}" \
+    ubuntu:24.04 /bin/sh -c '
+      mkdir -p /opt/axern/agents
+      ln -s /__claude_code /opt/axern/agents/claude-code
+      exec /opt/axern/agents/claude-code/bin/claude
+    ' >/dev/null
+  for _ in $(seq 1 50); do
+    proc_exe="$(docker exec "${proc_probe_container_name}" readlink /proc/1/exe 2>/dev/null || true)"
+    if [ "${proc_exe}" = "/__claude_code/opt/axern/agent-bundle/bin/claude.real" ]; then
+      break
+    fi
+    sleep 0.1
+  done
+  if [ "${proc_exe:-}" != "/__claude_code/opt/axern/agent-bundle/bin/claude.real" ]; then
+    echo "Claude /proc/self/exe identity is ${proc_exe:-missing}, want native executable" >&2
+    exit 1
+  fi
+  docker rm -f "${proc_probe_container_name}" >/dev/null
+
+  port_file="${extract_dir}/fake-anthropic.port"
+  PORT=0 PORT_FILE="${port_file}" python3 "$(dirname "$0")/testdata/fake_anthropic_tool_server.py" &
+  fake_server_pid=$!
+  for _ in $(seq 1 50); do
+    if [ -s "${port_file}" ]; then
+      break
+    fi
+    sleep 0.1
+  done
+  test -s "${port_file}"
+  fake_server_port="$(cat "${port_file}")"
+  tool_call_output="$(
+    docker run --rm --add-host host.docker.internal:host-gateway \
+      --volume "${extract_dir}:${mount_target}:ro" \
+      --env "AXRUN_AGENT_BUNDLE_MOUNT_TARGET=${public_mount_target}" \
+      --env "ANTHROPIC_BASE_URL=http://host.docker.internal:${fake_server_port}" \
+      --env ANTHROPIC_API_KEY=test \
+      --env CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1 \
+      --env LD_LIBRARY_PATH=/definitely-not-a-system-library \
+      ubuntu:24.04 /bin/sh -c '
+        set -eu
+        mkdir -p /opt/axern/agents /testbed /tmp/claude-home
+        ln -s /__claude_code /opt/axern/agents/claude-code
+        printf "config install patch\n" >/testbed/match.php
+        chown -R 65534:65534 /testbed /tmp/claude-home
+        cd /testbed
+        exec setpriv --reuid=65534 --regid=65534 --clear-groups \
+          env HOME=/tmp/claude-home /opt/axern/agents/claude-code/bin/claude \
+          -p "Run the requested check" --model claude-test \
+          --dangerously-skip-permissions --output-format stream-json --verbose
+      '
+  )"
+  printf '%s\n' "${tool_call_output}" | grep -F 'parent_exe=/__claude_code/opt/axern/agent-bundle/bin/claude.real' >/dev/null
+  printf '%s\n' "${tool_call_output}" | grep -F 'ld_library_path=unset' >/dev/null
+  printf '%s\n' "${tool_call_output}" | grep -F '/testbed/match.php' >/dev/null
+  if printf '%s\n' "${tool_call_output}" | grep -E -- '-S: error while loading shared libraries|cannot open shared object file' >/dev/null; then
+    echo "Claude Bash tool call regressed to the dynamic-loader self-restart failure" >&2
+    exit 1
+  fi
+  kill "${fake_server_pid}" >/dev/null 2>&1 || true
+  wait "${fake_server_pid}" >/dev/null 2>&1 || true
+  fake_server_pid=""
+fi
+
 wrong_target="/opt/axern/agents/noncanonical-${agent_id}"
+expected_canonical_target="${public_mount_target:-${mount_target}}"
 if wrong_output="$(
   docker run --rm \
     --volume "${extract_dir}:${wrong_target}:ro" \
@@ -104,7 +240,7 @@ if wrong_output="$(
   echo "agent bundle unexpectedly accepted non-canonical mount target ${wrong_target}" >&2
   exit 1
 fi
-printf '%s\n' "${wrong_output}" | grep -F "${mount_target}" >/dev/null
+printf '%s\n' "${wrong_output}" | grep -F "${expected_canonical_target}" >/dev/null
 
 for missing_relative in \
   opt/axern/agent-bundle/manifest.json \
@@ -118,8 +254,17 @@ for missing_relative in \
   missing_output="$(
     docker run --rm \
       --volume "${case_dir}:${mount_target}:ro" \
-      --env "AXRUN_AGENT_BUNDLE_MOUNT_TARGET=${mount_target}" \
-      busybox:1.36 "${mount_target}/bin/${binary}" --version 2>&1
+      --env "BUNDLE_AGENT_ID=${agent_id}" \
+      --env "BUNDLE_MOUNT_TARGET=${mount_target}" \
+      --env "BUNDLE_PUBLIC_MOUNT_TARGET=${public_mount_target:-${mount_target}}" \
+      --env "AXRUN_AGENT_BUNDLE_MOUNT_TARGET=${public_mount_target:-${mount_target}}" \
+      busybox:1.36 /bin/sh -c '
+        if [ "$BUNDLE_AGENT_ID" = claude-code ]; then
+          mkdir -p /opt/axern/agents
+          ln -s "$BUNDLE_MOUNT_TARGET" "$BUNDLE_PUBLIC_MOUNT_TARGET"
+        fi
+        "$BUNDLE_PUBLIC_MOUNT_TARGET/bin/'"${binary}"'" --version
+      ' 2>&1
   )"
   missing_status=$?
   set -e
@@ -135,6 +280,9 @@ printf '%s\n' "${labels}" | grep -F "\"io.axern.agent-bundle.agent-id\":\"${agen
 printf '%s\n' "${labels}" | grep -F "\"io.axern.agent-bundle.agent-version\":\"${agent_version}\"" >/dev/null
 printf '%s\n' "${labels}" | grep -F "\"io.axern.agent-bundle.architecture\":\"linux/${image_arch}\"" >/dev/null
 printf '%s\n' "${labels}" | grep -F "\"io.axern.agent-bundle.mount-target\":\"${mount_target}\"" >/dev/null
+if [ "${agent_id}" = claude-code ]; then
+  printf '%s\n' "${labels}" | grep -F '"io.axern.agent-bundle.public-mount-target":"/opt/axern/agents/claude-code"' >/dev/null
+fi
 printf '%s\n' "${labels}" | grep -F "\"io.axern.agent-bundle.entrypoint\":\"/bin/${binary}\"" >/dev/null
 python3 - "${extract_dir}/opt/axern/agent-bundle/manifest.json" "${labels}" <<'PY'
 import json
@@ -154,6 +302,8 @@ mapping = {
 }
 if "node_version" in manifest:
     mapping["node_version"] = "io.axern.agent-bundle.node-version"
+if "public_mount_target" in manifest:
+    mapping["public_mount_target"] = "io.axern.agent-bundle.public-mount-target"
 for manifest_key, label_key in mapping.items():
     if manifest.get(manifest_key) != labels.get(label_key):
         raise SystemExit(

--- a/scripts/dev-env/compose-claude-code-image-mount-smoke.sh
+++ b/scripts/dev-env/compose-claude-code-image-mount-smoke.sh
@@ -37,7 +37,7 @@ trap 'cleanup_build_dir; end_env_lock compose' EXIT
 cat >"${build_dir}/Task.Dockerfile" <<'EOF'
 ARG TASK_BASE_IMAGE
 FROM ${TASK_BASE_IMAGE}
-RUN mkdir -p /opt/axern/agents/claude-code
+RUN mkdir -p /opt/axern/agents
 EOF
 
 task_source_image="axern/claude-code-image-mount-smoke-task:local"
@@ -118,9 +118,9 @@ create_output="$(
   local_smoke_json_once_or_recover_by_namespace run runs run "${namespace}" \
     "${AXERN_SMOKE_CMD[@]}" run --detach -o json \
       --namespace "${namespace}" \
-      --image-mount "${bundle_cluster_image}:/opt/axern/agents/claude-code:ro" \
+      --image-mount "${bundle_cluster_image}:/__claude_code:ro" \
       "${task_cluster_image}" -- /bin/sh -lc \
-      'test -r /opt/axern/agents/claude-code/opt/axern/agent-bundle/manifest.json && LD_LIBRARY_PATH=/definitely-not-a-system-library /opt/axern/agents/claude-code/bin/claude --version | tee /tmp/claude-version.txt && grep -F "Claude Code" /tmp/claude-version.txt && ! touch /opt/axern/agents/claude-code/write-test && /bin/sh -c "printf sandbox-ok" && printf "\nagent-bundle-smoke-ready\n" && sleep 600' || true
+      'test "$(readlink /opt/axern/agents/claude-code)" = /__claude_code && test -r /__claude_code/opt/axern/agent-bundle/manifest.json && LD_LIBRARY_PATH=/definitely-not-a-system-library /opt/axern/agents/claude-code/bin/claude --version | tee /tmp/claude-version.txt && grep -F "Claude Code" /tmp/claude-version.txt && ! touch /__claude_code/write-test && /bin/sh -c "printf sandbox-ok" && printf "\nagent-bundle-smoke-ready\n" && sleep 600' || true
 )"
 if ! run_id="$(extract_run_json_field id <<<"${create_output}" 2>/dev/null)"; then
   printf '%s\n' "${create_output}" >&2

--- a/scripts/release/image-build-contract-check.sh
+++ b/scripts/release/image-build-contract-check.sh
@@ -49,6 +49,14 @@ if "axern_docker_build" not in runtime_build:
 if "docker buildx build" in runtime_build:
     raise SystemExit("node runtime base must not bypass the shared Docker build cache helper")
 
+node_runtime_dockerfile = (root / "deploy/images/lib/node-runtime-base.Dockerfile").read_text()
+for contract in (
+    "COPY lib/go/agentbundle/go.mod /workspace/lib/go/agentbundle/go.mod",
+    "./lib/go/agentbundle",
+):
+    if contract not in node_runtime_dockerfile:
+        raise SystemExit(f"node runtime base is missing the agentbundle module staging contract: {contract}")
+
 cache_helper = (root / "scripts/dev-env/docker-build-cache.sh").read_text()
 source_label = '--label "org.opencontainers.image.source=${AXERN_OCI_SOURCE_LABEL}"'
 if source_label not in cache_helper:
@@ -89,16 +97,35 @@ for agent_id, dockerfile in bundle_contracts.items():
         bundle_base,
         f'io.axern.agent-bundle.agent-id="{agent_id}"',
         'io.axern.agent-bundle.architecture="linux/${TARGETARCH}"',
-        f'io.axern.agent-bundle.mount-target="/opt/axern/agents/{agent_id}"',
         "/opt/axern/agent-bundle/manifest.json",
         "readelf -h",
-        "--library-path",
         "--list",
     ):
         if contract not in text:
             raise SystemExit(f"{agent_id} self-contained bundle contract is missing: {contract}")
 
+claude_dockerfile = bundle_contracts["claude-code"].read_text()
+claude_build = (bundle_contracts["claude-code"].parent / "build-bundle.sh").read_text()
+claude_wrapper = (bundle_contracts["claude-code"].parent / "claude").read_text()
+for contract in (
+    'io.axern.agent-bundle.mount-target="/__claude_code"',
+    'io.axern.agent-bundle.public-mount-target="/opt/axern/agents/claude-code"',
+    "canonical_root=/__claude_code",
+    'loader_wrapped_elfs: []',
+    'exec "$real_binary" "$@"',
+):
+    if contract not in claude_dockerfile + claude_build + claude_wrapper:
+        raise SystemExit(f"Claude Code dual-path bundle contract is missing: {contract}")
+if '--library-path' in claude_wrapper:
+    raise SystemExit("Claude Code wrapper must execute its native ELF without a loader wrapper")
+
 codex_bundle = bundle_contracts["codex"].read_text() + (bundle_contracts["codex"].parent / "build-bundle.sh").read_text()
+for contract in (
+    'io.axern.agent-bundle.mount-target="/opt/axern/agents/codex"',
+    "--library-path",
+):
+    if contract not in codex_bundle:
+        raise SystemExit(f"Codex bundle contract is missing: {contract}")
 for checksum in (
     "e798599612f4bb71333a3397ab0d095fd62214e115aea45aa858a145fc72d67e",
     "aa881151bd0f9f154a0424dd60a72e9ce10672619121658c278a24327ef46831",


### PR DESCRIPTION
## Summary

- Mount the Claude Code bundle exactly once at the private ABI target `/__claude_code`, while keeping the user-facing entrypoint at `/opt/axern/agents/claude-code`.
- Seed the public path as an allocation-private rootfs symlink during OCI preparation and fail safely when that path is already occupied.
- Keep generic agent layout behavior unchanged, model the Claude private ABI mapping explicitly, and reserve both paths during mount conflict validation.
- Preserve Claude's native ELF identity with `PT_INTERP=/__claude_code/l`; the launcher now directly execs the native binary without a loader wrapper or global `LD_LIBRARY_PATH`.
- Upgrade the bundle manifest/build contract and add end-to-end regressions for the original Bash tool-call failure.

## Root cause

The previous launcher invoked the dynamic loader with `--library-path`. When Bun/Claude Code restarted itself through `/proc/self/exe`, that path identified the loader rather than the Claude native ELF, so the internal `-S` argument was interpreted by the loader and failed with `-S: error while loading shared libraries`.

## Runtime behavior

- One read-only bind mount: `/__claude_code`
- Public alias: `/opt/axern/agents/claude-code -> /__claude_code`
- Native interpreter: `/__claude_code/l`
- No double bind mount
- No launcher loader wrapper
- No global `LD_LIBRARY_PATH`
- Existing public-path content causes a safe startup failure

## Validation

- Forge CN cold build (Aliyun APT mirror, no image reuse):
  - `scripts/axern/run-cn-accelerated.sh --exec bash runtime/axnoded/scripts/runtime/build-claude-code-bundle-image.sh`
  - Built `axern/claude-code-bundle:dev` as `sha256:652fda0ba5f0d7ee9d9caa76b39ba932802d39b3a4e32ed54b0b4319a88c200f`
  - Completed with `agent_bundle_image_verified=true`
- BusyBox 1.36 and Ubuntu 24.04 read-only single-mount matrix
- `PT_INTERP=/__claude_code/l`
- `/proc/self/exe=/__claude_code/opt/axern/agent-bundle/bin/claude.real`
- Public-path invocation succeeds with an intentionally invalid inherited `LD_LIBRARY_PATH`
- Original Bash tool-call pipeline succeeds and reports `ld_library_path=unset`, without the `-S` loader error
- `go test ./...` in `apps/cli`
- Agent bundle, axrun, rootfsflow, rootfsview, allocation, and controld public API tests
- axnoded and controld architecture checks
- agent documentation contract check
