### PR TITLE
fix(release): configure kind memory reserve

### DIFF
--- a/scripts/release/kind-acceptance.sh
+++ b/scripts/release/kind-acceptance.sh
@@ -10,6 +10,13 @@ namespace="axern-release"
 cluster="axern-release"
 chart="${AXERN_HELM_CHART:-oci://ghcr.io/cofy-x/charts/axern}"
 image_tag_suffix="${AXERN_RELEASE_IMAGE_TAG_SUFFIX:-}"
+# This disposable kind cluster exercises the required cgroup path with an
+# explicit non-production reserve; production values still come from a receipt.
+release_test_memory_system_reserve_bytes="${AXERN_RELEASE_TEST_MEMORY_SYSTEM_RESERVE_BYTES:-536870912}"
+if ! [[ "${release_test_memory_system_reserve_bytes}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "AXERN_RELEASE_TEST_MEMORY_SYSTEM_RESERVE_BYTES must be a positive decimal integer" >&2
+  exit 1
+fi
 state_dir="$(mktemp -d)"
 cleanup() {
   jobs -p | xargs kill >/dev/null 2>&1 || true
@@ -40,6 +47,7 @@ helm_args=(
   install axern "${chart}"
   --namespace "${namespace}"
   --wait --timeout 15m
+  --set-string "node.memorySystemReserveBytes=${release_test_memory_system_reserve_bytes}"
 )
 if [[ "${chart}" == oci://* ]]; then
   helm_args+=(--version "${tag#v}")

--- a/scripts/release/sdk-data-plane-contract-check.sh
+++ b/scripts/release/sdk-data-plane-contract-check.sh
@@ -45,6 +45,9 @@ if "AXERN_RELEASE_VERSION:" in global_env:
 
 harness = (root / "scripts/release/kind-acceptance.sh").read_text()
 for value in (
+    "AXERN_RELEASE_TEST_MEMORY_SYSTEM_RESERVE_BYTES:-536870912",
+    "AXERN_RELEASE_TEST_MEMORY_SYSTEM_RESERVE_BYTES must be a positive decimal integer",
+    'node.memorySystemReserveBytes=${release_test_memory_system_reserve_bytes}',
     "AXERN_SDK_ACCEPTANCE_CONFIG",
     "AXERN_SDK_ACCEPTANCE_CONTEXT=release",
     "AXERN_SDK_ACCEPTANCE_CLI",
@@ -83,5 +86,11 @@ for value in ('print("hello from axern")', 'print("hello from stderr"', "run_sta
 if (root / "scripts/release/verify-published-sdks.sh").exists():
     raise SystemExit("obsolete import-only published SDK verifier must not exist")
 PY
+
+if AXERN_RELEASE_TEST_MEMORY_SYSTEM_RESERVE_BYTES=0 \
+  bash "${AXERN_ROOT}/scripts/release/kind-acceptance.sh" >/dev/null 2>&1; then
+  echo "kind acceptance accepted an invalid test memory system reserve" >&2
+  exit 1
+fi
 
 echo "sdk_data_plane_contract_ok=true"


### PR DESCRIPTION
## Summary

- Configure the disposable Release kind cluster with an explicit 512 MiB test memory-system reserve.
  - Keep the production Helm chart fail-closed and without a default reserve.
  - Allow the acceptance-only value to be overridden through `AXERN_RELEASE_TEST_MEMORY_SYSTEM_RESERVE_BYTES`.
  - Reject zero, negative, and malformed values before creating the kind cluster.
- Extend the existing release contract check to prevent the required Helm value from being omitted again.

## Root cause

Release qualification run [31787781454](https://github.com/cofy-x/axern/actions/runs/31787781454) failed in `candidate-acceptance` before deployment because `kind-acceptance.sh` did not pass the newly required `node.memorySystemReserveBytes` Helm value.

No v0.5.0 tags were created, so the release version remains v0.5.0. After this change is merged, the candidate workflow must be rerun against the new `main` commit before the first annotated tags are created.

## Validation

- `bash -n scripts/release/kind-acceptance.sh scripts/release/sdk-data-plane-contract-check.sh`
- `bash scripts/release/sdk-data-plane-contract-check.sh`
- Helm template with `node.memorySystemReserveBytes=536870912`
- `make release-check`
- `make release-build`
- `git diff --check`
