### PR TITLE
fix(release): bound candidate smoke resources

### DIFF
--- a/apps/cli/internal/localbundle/assets/compose.yaml
+++ b/apps/cli/internal/localbundle/assets/compose.yaml
@@ -169,6 +169,11 @@ services:
       AXNODED_CONTROL_PLANE_TLS_CERT: /certs/node.crt
       AXNODED_CONTROL_PLANE_TLS_KEY: /certs/node.key
       AXNODED_DNS_NAMESERVERS: ${AXNODED_DNS_NAMESERVERS}
+      # Docker Desktop and generic local Compose do not provide Axern's
+      # production cgroup delegation contract. Hard-limit qualification runs
+      # in the dedicated Linux gates instead.
+      AXNODED_CGROUP_ENFORCEMENT: disabled_dev
+      AXNODED_MEMORY_SYSTEM_RESERVE_BYTES: "0"
       REGISTRY_PROXY_URL: ${REGISTRY_PROXY_URL}
       REGISTRY_NO_PROXY: ${CONTAINER_NO_PROXY}
       HTTP_PROXY: ${CONTAINER_HTTP_PROXY}

--- a/apps/cli/internal/localbundle/bundle_test.go
+++ b/apps/cli/internal/localbundle/bundle_test.go
@@ -18,6 +18,14 @@ func TestEmbeddedBundleIsSelfContainedAndLoopbackOnly(t *testing.T) {
 	if !bytes.Contains(Compose, []byte("AXNODED_DNS_NAMESERVERS: ${AXNODED_DNS_NAMESERVERS}")) {
 		t.Fatal("local bundle does not pass resolved workload DNS to axnoded")
 	}
+	for _, contract := range []string{
+		"AXNODED_CGROUP_ENFORCEMENT: disabled_dev",
+		"AXNODED_MEMORY_SYSTEM_RESERVE_BYTES: \"0\"",
+	} {
+		if !bytes.Contains(Compose, []byte(contract)) {
+			t.Fatalf("local bundle is missing the local cgroup contract %q", contract)
+		}
+	}
 	for _, port := range []string{"POSTGRES_PORT", "MINIO_API_PORT", "MINIO_CONSOLE_PORT", "CONTROLD_HTTP_PORT", "GATEWAY_CONTROL_PORT", "GATEWAY_HTTP_PORT", "GATEWAY_SSH_PORT", "OTEL_GRPC_PORT", "OTEL_HTTP_PORT", "LGTM_UI_PORT"} {
 		mapping := []byte("127.0.0.1:${" + port + "}:")
 		if !bytes.Contains(Compose, mapping) {

--- a/scripts/release/kind-acceptance.sh
+++ b/scripts/release/kind-acceptance.sh
@@ -135,7 +135,10 @@ spec:
   command:
     argv: [python, -c, "print('axern-release-ok')"]
   runtime_class: runsc
-  resources: {}
+  resources:
+    requests:
+      cpu: 100m
+      memory: 512MiB
 YAML
 "${cli}" --config "${config}" --timeout 10m run --file "${state_dir}/run.yaml"
 

--- a/scripts/release/local-release-smoke.sh
+++ b/scripts/release/local-release-smoke.sh
@@ -40,14 +40,14 @@ common=(--config "${config}" --timeout 10m)
 "${cli}" "${common[@]}" local status --output json | grep -q '"state": "running"'
 stdout_file="${smoke_root}/run.stdout"
 stderr_file="${smoke_root}/run.stderr"
-"${cli}" "${common[@]}" run python:3.12-slim -- \
+"${cli}" "${common[@]}" run --request-cpu 100m --request-memory 512MiB python:3.12-slim -- \
   python -c 'import sys; print("hello from axern"); print("hello from stderr", file=sys.stderr)' \
   >"${stdout_file}" 2>"${stderr_file}"
 grep -Fxq "hello from axern" "${stdout_file}"
 grep -Fq "hello from stderr" "${stderr_file}"
 
 set +e
-"${cli}" "${common[@]}" run python:3.12-slim -- python -c 'raise SystemExit(7)' \
+"${cli}" "${common[@]}" run --request-cpu 100m --request-memory 512MiB python:3.12-slim -- python -c 'raise SystemExit(7)' \
   >"${smoke_root}/exit.stdout" 2>"${smoke_root}/exit.stderr"
 run_status=$?
 set -e

--- a/scripts/release/sdk-data-plane-contract-check.sh
+++ b/scripts/release/sdk-data-plane-contract-check.sh
@@ -53,6 +53,8 @@ for value in (
     "AXERN_SDK_ACCEPTANCE_CLI",
     "namespace create default --output json",
     "doctor --namespace default --output json",
+    "cpu: 100m",
+    "memory: 512MiB",
 ):
     if value not in harness:
         raise SystemExit(f"kind acceptance is missing SDK hook contract: {value}")
@@ -72,6 +74,8 @@ for fixture in fixtures:
     for value in ("service-id", "python311", "runsc", "release-ok", "AXERN_SDK_ACCEPTANCE_HANDSHAKE_DIR"):
         if value not in text:
             raise SystemExit(f"{fixture.relative_to(root)} is missing acceptance behavior: {value}")
+    if "100m" not in text or "512MiB" not in text:
+        raise SystemExit(f"{fixture.relative_to(root)} must declare bounded release-smoke resources")
 
 acceptance = (root / "scripts/release/sdk-data-plane-acceptance.sh").read_text()
 for value in ("service get", '${language}.service-id', "run_sdk python", "run_sdk typescript", "run_sdk go"):
@@ -79,7 +83,7 @@ for value in ("service get", '${language}.service-id', "run_sdk python", "run_sd
         raise SystemExit(f"SDK data-plane harness is missing CLI handshake contract: {value}")
 
 local_smoke = (root / "scripts/release/local-release-smoke.sh").read_text()
-for value in ('print("hello from axern")', 'print("hello from stderr"', "run_status", '"${run_status}" -ne 7'):
+for value in ('print("hello from axern")', 'print("hello from stderr"', "run_status", '"${run_status}" -ne 7', "--request-cpu 100m --request-memory 512MiB"):
     if value not in local_smoke:
         raise SystemExit(f"local release smoke is missing foreground Run behavior: {value}")
 

--- a/scripts/release/sdk-data-plane/main.go
+++ b/scripts/release/sdk-data-plane/main.go
@@ -44,11 +44,13 @@ func main() {
 	defer client.Close()
 
 	sandbox, err := axern.NewSandbox(axern.SandboxOptions{
-		Client:       client,
-		TemplateID:   "python311",
-		RuntimeClass: "runsc",
-		ReadyTimeout: 3 * time.Minute,
-		Labels:       map[string]string{"axern.release.acceptance": "go"},
+		Client:        client,
+		TemplateID:    "python311",
+		RuntimeClass:  "runsc",
+		RequestCPU:    "100m",
+		RequestMemory: "512MiB",
+		ReadyTimeout:  3 * time.Minute,
+		Labels:        map[string]string{"axern.release.acceptance": "go"},
 	})
 	check(err)
 	check(sandbox.Start(ctx))

--- a/scripts/release/sdk-data-plane/python.py
+++ b/scripts/release/sdk-data-plane/python.py
@@ -23,6 +23,8 @@ def main() -> None:
             client=client,
             template_id="python311",
             runtime_class="runsc",
+            request_cpu="100m",
+            request_memory="512MiB",
             labels={"axern.release.acceptance": "python"},
         ) as sandbox:
             result = sandbox.exec(["python", "-c", f"print({marker!r})"], check=True, text=True)

--- a/scripts/release/sdk-data-plane/typescript.mjs
+++ b/scripts/release/sdk-data-plane/typescript.mjs
@@ -16,6 +16,8 @@ try {
     client,
     templateId: "python311",
     runtimeClass: "runsc",
+    requestCpu: "100m",
+    requestMemory: "512MiB",
     labels: { "axern.release.acceptance": "typescript" },
   }).start();
   const result = await sandbox.exec(["python", "-c", `print(${JSON.stringify(marker)})`], { check: true });


### PR DESCRIPTION
## Summary

- make the CLI-bundled local Compose deployment explicitly use the supported `disabled_dev` cgroup contract with zero system reserve
- give Kind, local CLI, and all three SDK release smoke workloads bounded CPU and sandbox-memory requests instead of inheriting the 4 GiB product default
- add release and embedded-bundle contract checks so these deployment paths cannot silently drift again

## Root cause

- the first release fix configured `node.memorySystemReserveBytes` only for the Kind Helm path; the CLI-embedded Compose asset still started axnoded with the production `required` default and no reserve
- after Kind became healthy, its trivial smoke Run inherited the 4 GiB default request, which exceeded the GitHub runner's effective allocatable memory
- the subsequent Python, TypeScript, and Go SDK fixtures had the same implicit request and would have failed next

## Validation

- `git diff --check`
- `make release-check`
- `make axern-cli-build`
- `go test ./apps/cli/... ./sdk/go/...`
- `go vet ./apps/cli/...`
- `make axern-cli-check-architecture`
- `make sdk-typescript-verify`
