### PR TITLE
fix(release): expose conformance cleanup failures

### DIFF
--- a/runtime/axnoded/internal/container/manager.go
+++ b/runtime/axnoded/internal/container/manager.go
@@ -268,16 +268,19 @@ func (m *Manager) MemoryCommitment() (resourcemanager.MemoryCommitment, error) {
 	return reporter.MemoryCommitment(), nil
 }
 
-func (m *Manager) CgroupCleanupPending(allocationID string) (bool, error) {
+func (m *Manager) CgroupCleanupStatus(allocationID string) (bool, string, error) {
 	manager, ok := m.resourceManagers.Get(string(resourcemanager.CgroupResourceName))
 	if !ok {
-		return false, fmt.Errorf("cgroup resource manager is unavailable")
+		return false, "", fmt.Errorf("cgroup resource manager is unavailable")
 	}
-	reporter, ok := manager.(interface{ HasAllocationLease(string) bool })
+	reporter, ok := manager.(interface {
+		AllocationLeaseCleanupStatus(string) (bool, string)
+	})
 	if !ok {
-		return false, fmt.Errorf("cgroup resource manager does not publish allocation ownership")
+		return false, "", fmt.Errorf("cgroup resource manager does not publish allocation cleanup status")
 	}
-	return reporter.HasAllocationLease(allocationID), nil
+	pending, detail := reporter.AllocationLeaseCleanupStatus(allocationID)
+	return pending, detail, nil
 }
 
 func (m *Manager) RetiringMemoryLeases() []resourcemanager.RetiringMemoryLease {

--- a/runtime/axnoded/internal/resources/cgroup_manager.go
+++ b/runtime/axnoded/internal/resources/cgroup_manager.go
@@ -278,21 +278,26 @@ func (c *CgroupManager) MemoryCommitment() MemoryCommitment {
 	return c.memoryCommitmentLocked(time.Now().UTC())
 }
 
-// HasAllocationLease reports whether the durable ledger still owns a cgroup
-// for allocationID. Assigned and retiring leases both count: callers must not
-// treat memory capacity as released until the retiring lease is removed.
-func (c *CgroupManager) HasAllocationLease(allocationID string) bool {
+// AllocationLeaseCleanupStatus reports whether allocationID still owns a
+// durable cgroup lease and, when GC has attempted retirement, the latest
+// bounded kernel cleanup error. The diagnostic is intentionally node-local:
+// durable lease ownership remains the admission authority, while callers that
+// wait for convergence need enough evidence to distinguish a live process,
+// identity mismatch, and filesystem removal failure. Assigned and retiring
+// leases both count: callers must not treat memory capacity as released until
+// the retiring lease is removed.
+func (c *CgroupManager) AllocationLeaseCleanupStatus(allocationID string) (bool, string) {
 	if allocationID == "" {
-		return false
+		return false, ""
 	}
 	c.Lock()
 	defer c.Unlock()
 	for item := range c.leases.IterBuffered() {
 		if item.Val != nil && item.Val.GetAllocationID() == allocationID {
-			return true
+			return true, item.Val.GetLastCleanupError()
 		}
 	}
-	return false
+	return false, ""
 }
 
 func (c *CgroupManager) setPoolController(controller *poolController) {

--- a/runtime/axnoded/internal/resources/cgroup_pool_test.go
+++ b/runtime/axnoded/internal/resources/cgroup_pool_test.go
@@ -262,6 +262,24 @@ func TestCgroupManagerRecycleIsOneWayIntoRetirement(t *testing.T) {
 	}
 }
 
+func TestCgroupManagerAllocationLeaseCleanupStatusIncludesLastError(t *testing.T) {
+	manager := &CgroupManager{leases: cmap.New[*apipb.CgroupLease]()}
+	manager.leases.Set("/sandbox/retiring", &apipb.CgroupLease{
+		CgroupID:         "/sandbox/retiring",
+		AllocationID:     "alloc-a",
+		State:            apipb.CgroupLifecycleState_CGROUP_LIFECYCLE_STATE_RETIRING,
+		LastCleanupError: "retiring cgroup still contains 1 process(es)",
+	})
+
+	pending, detail := manager.AllocationLeaseCleanupStatus("alloc-a")
+	if !pending || detail != "retiring cgroup still contains 1 process(es)" {
+		t.Fatalf("AllocationLeaseCleanupStatus() = (%t, %q)", pending, detail)
+	}
+	if pending, detail := manager.AllocationLeaseCleanupStatus("missing"); pending || detail != "" {
+		t.Fatalf("missing AllocationLeaseCleanupStatus() = (%t, %q)", pending, detail)
+	}
+}
+
 func TestCgroupManagerRecycleFailsClosedBeforeIdentityMismatchCanReleaseCommitment(t *testing.T) {
 	manager := &CgroupManager{
 		usingID: cmap.New[struct{}](), idleID: queue.New(""), leases: cmap.New[*apipb.CgroupLease](),

--- a/runtime/axnoded/internal/service/runtime_conformance.go
+++ b/runtime/axnoded/internal/service/runtime_conformance.go
@@ -466,12 +466,15 @@ func (h *sandboxService) verifyRuntimeConformanceCleanup(ctx context.Context, al
 			}
 		}
 		if remaining == "" && verifyCgroup {
-			pending, err := h.containerManager.CgroupCleanupPending(allocationID)
+			pending, detail, err := h.containerManager.CgroupCleanupStatus(allocationID)
 			if err != nil {
 				return fmt.Errorf("verify self-test cgroup cleanup: %w", err)
 			}
 			if pending {
 				remaining = "durable cgroup lease"
+				if detail != "" {
+					remaining += " (last cleanup error: " + detail + ")"
+				}
 			}
 		}
 		if remaining == "" {

--- a/scripts/release/kind-acceptance.sh
+++ b/scripts/release/kind-acceptance.sh
@@ -209,6 +209,9 @@ PY
   kubectl --namespace "${namespace}" get pods -o wide >&2 || true
   echo "--- node logs ---" >&2
   kubectl --namespace "${namespace}" logs daemonset/node-all-in-one --all-containers --tail=300 >&2 || true
+  echo "--- axnoded file log ---" >&2
+  kubectl --namespace "${namespace}" exec daemonset/node-all-in-one -- \
+    sh -c 'tail -n 500 /var/log/axnoded/axnoded.log' >&2 || true
   return 1
 }
 


### PR DESCRIPTION
## Summary

- expose the latest durable cgroup retirement error when runtime conformance cleanup times out
- export the actual axnoded file log from Kind candidate readiness failures
- keep cleanup and capability admission fail-closed

## Validation

- `go test ./internal/resources ./internal/container ./internal/service`
- `make -C runtime/axnoded check-architecture`
- `make -C runtime/axnoded test-host`
- `make agent-doc-check`
- `git diff --check`
- `bash -n scripts/release/kind-acceptance.sh`