### PR TITLE
feat(sdk): expose sandbox network policies

### DIFF
--- a/scripts/release/sdk-python-artifact-smoke.py
+++ b/scripts/release/sdk-python-artifact-smoke.py
@@ -4,7 +4,7 @@ import sys
 
 import axern_sdk
 from axern.control.environment.v1 import environment_pb2
-from axern_sdk import AxernClient, Sandbox
+from axern_sdk import AxernClient, NetworkPolicy, Sandbox
 
 
 def main() -> None:
@@ -18,6 +18,9 @@ def main() -> None:
     for method in ("capability_status", "computer_use_status", "computer_use_screenshot"):
         if not callable(getattr(Sandbox, method, None)):
             raise SystemExit(f"Python SDK artifact is missing Sandbox.{method}")
+    policy = NetworkPolicy.deny_dns("GitHub.COM.", "*.github.com")
+    if list(policy._to_proto().dns_deny.denied_domains) != ["github.com", "*.github.com"]:
+        raise SystemExit("Python SDK artifact cannot construct a DNS deny policy")
 
 
 if __name__ == "__main__":

--- a/scripts/release/verify-sdk-artifacts.sh
+++ b/scripts/release/verify-sdk-artifacts.sh
@@ -40,7 +40,7 @@ const sdk = await import(pathToFileURL(path.join(prefix, "node_modules/@cofy-x/a
 if (sdk.AXERN_VERSION !== expected || sdk.platformName() !== "axern") {
   throw new Error(`unexpected TypeScript SDK metadata: ${sdk.AXERN_VERSION}`);
 }
-for (const symbol of ["AxernClient", "Sandbox", "NodeSandboxClient"]) {
+for (const symbol of ["AxernClient", "Sandbox", "NodeSandboxClient", "NetworkPolicy"]) {
   if (typeof sdk[symbol] !== "function") {
     throw new Error(`missing TypeScript SDK export ${symbol}`);
   }
@@ -50,12 +50,17 @@ for (const method of ["capabilityStatus", "computerUseStatus", "computerUseScree
     throw new Error(`missing TypeScript SDK method ${method}`);
   }
 }
+const networkPolicy = sdk.NetworkPolicy.denyDns("GitHub.COM.", "*.github.com");
+if (JSON.stringify(networkPolicy.toWire()) !== JSON.stringify({ dns_deny: { denied_domains: ["github.com", "*.github.com"] } })) {
+  throw new Error("TypeScript SDK artifact cannot construct a DNS deny policy");
+}
 NODE
 
 cat > "${npm_prefix}/consumer.mts" <<'TS'
 import {
   AXERN_VERSION,
   AxernClient,
+  NetworkPolicy,
   Sandbox,
   type CapabilityStatus,
   type ComputerUseScreenshot,
@@ -66,6 +71,7 @@ declare const sandbox: Sandbox;
 declare const capabilities: CapabilityStatus;
 declare const screenshot: ComputerUseScreenshot;
 void [AXERN_VERSION, client, sandbox, capabilities, screenshot];
+void NetworkPolicy.denyDns("github.com", "*.github.com");
 TS
 pnpm --dir "${AXERN_ROOT}" exec tsc \
   --noEmit --strict --target ES2022 --module NodeNext --moduleResolution NodeNext \
@@ -112,6 +118,10 @@ func TestPublicSurface(t *testing.T) {
 		TLS: clientconfig.TLS{CACert: "ca", Cert: "cert", Key: "key"},
 	}); err != nil {
 		t.Fatal(err)
+	}
+	policy, err := axern.DenyDNSNetworkPolicy("GitHub.COM.", "*.github.com")
+	if err != nil || policy == nil {
+		t.Fatalf("Go SDK artifact cannot construct a DNS deny policy: %v", err)
 	}
 }
 GO

--- a/sdk/contracts/v1/network_policies.json
+++ b/sdk/contracts/v1/network_policies.json
@@ -1,0 +1,28 @@
+{
+  "domains": {
+    "input": ["GitHub.COM.", "github.com", "*.BÜCHER.example"],
+    "normalized": ["github.com", "*.xn--bcher-kva.example"]
+  },
+  "cidr": {
+    "cidr": "192.0.2.0/24",
+    "protocol": "tcp",
+    "ports": [
+      {"start": 22, "end": 22},
+      {"start": 8000, "end": 8002}
+    ]
+  },
+  "invalid_domains": [
+    "https://example.com",
+    "example.com:443",
+    "127.0.0.1",
+    "foo.*.example"
+  ],
+  "invalid_cidrs": [
+    "not-a-cidr",
+    "169.254.169.254/32",
+    "100.100.100.200/32",
+    "127.0.0.1/32",
+    "::1/128",
+    "fe80::1/128"
+  ]
+}

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -117,6 +117,34 @@ func main() {
 }
 ```
 
+## Network Policies
+
+Leaving `SandboxOptions.NetworkPolicy` nil preserves unrestricted v0.5
+behavior. Strict policies are fail-closed; DNS deny only refuses matching
+traditional UDP/TCP DNS queries and does not block direct IP traffic, DoH, DoT,
+or already-resolved addresses.
+
+```go
+policy, err := axern.DenyDNSNetworkPolicy(
+	"github.com",
+	"*.github.com",
+	"githubusercontent.com",
+	"*.githubusercontent.com",
+)
+if err != nil {
+	log.Fatal(err)
+}
+sandbox, err := axern.NewSandbox(axern.SandboxOptions{
+	Client:        client,
+	Image:         "docker.io/library/python:3.12-slim",
+	NetworkPolicy: policy,
+})
+```
+
+`AllowDomainNetworkPolicy` allows only strict HTTP/HTTPS destinations validated
+by DNS plus HTTP Host or TLS SNI. `NewStrictNetworkPolicy` also accepts explicit
+TCP/UDP CIDR and port grants; `DenyAllNetworkPolicy` allows no egress.
+
 Run a tool from a separate image against a host-backed sandbox workspace with
 `ExecImage` or `ProcessImage`. The image ref may point to an OCI or Nydus image;
 Axern resolves both through the same runtime image path. When `Mounts` is nil,

--- a/sdk/go/contract_test.go
+++ b/sdk/go/contract_test.go
@@ -64,6 +64,20 @@ type commonCoreContract struct {
 	AgentSandbox []string `json:"agent_sandbox"`
 }
 
+type networkPolicyContract struct {
+	Domains struct {
+		Input      []string `json:"input"`
+		Normalized []string `json:"normalized"`
+	} `json:"domains"`
+	CIDR struct {
+		CIDR     string      `json:"cidr"`
+		Protocol string      `json:"protocol"`
+		Ports    []PortRange `json:"ports"`
+	} `json:"cidr"`
+	InvalidDomains []string `json:"invalid_domains"`
+	InvalidCIDRs   []string `json:"invalid_cidrs"`
+}
+
 func TestSharedResourceContract(t *testing.T) {
 	var contract resourceContract
 	loadContract(t, "resources.json", &contract)
@@ -218,6 +232,32 @@ func TestSharedCommonCoreContract(t *testing.T) {
 		"computer_use_mouse":      "ComputerUseMouse",
 		"computer_use_keyboard":   "ComputerUseKeyboard",
 	})
+}
+
+func TestSharedNetworkPolicyContract(t *testing.T) {
+	var contract networkPolicyContract
+	loadContract(t, "network_policies.json", &contract)
+	policy, err := DenyDNSNetworkPolicy(contract.Domains.Input...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := policy.proto().GetDnsDeny().GetDeniedDomains(); !reflect.DeepEqual(got, contract.Domains.Normalized) {
+		t.Fatalf("normalized domains = %v, want %v", got, contract.Domains.Normalized)
+	}
+	cidrPolicy, err := NewStrictNetworkPolicy(nil, []CIDRRule{{CIDR: contract.CIDR.CIDR, Protocol: EgressProtocol(contract.CIDR.Protocol), Ports: contract.CIDR.Ports}})
+	if err != nil || cidrPolicy.proto().GetStrict().GetAllowedCidrs()[0].GetCidr() != contract.CIDR.CIDR {
+		t.Fatalf("CIDR policy = %v, %v", cidrPolicy, err)
+	}
+	for _, value := range contract.InvalidDomains {
+		if _, err := AllowDomainNetworkPolicy(value); err == nil {
+			t.Fatalf("invalid domain %q succeeded", value)
+		}
+	}
+	for _, value := range contract.InvalidCIDRs {
+		if _, err := NewStrictNetworkPolicy(nil, []CIDRRule{{CIDR: value, Protocol: EgressProtocolTCP, Ports: []PortRange{{Start: 443}}}}); err == nil {
+			t.Fatalf("invalid CIDR %q succeeded", value)
+		}
+	}
 }
 
 func publicMethods(target reflect.Type) map[string]bool {

--- a/sdk/go/control_api.go
+++ b/sdk/go/control_api.go
@@ -65,6 +65,7 @@ type CreateServiceOptions struct {
 	Env                     map[string]string
 	Cwd                     string
 	RuntimeClass            string
+	NetworkPolicy           *NetworkPolicy
 	ExtensionCapabilities   []ExtensionCapability
 	Volumes                 []VolumeMount
 	ImageMounts             []ImageMount
@@ -105,6 +106,7 @@ func (c *Client) CreateService(ctx context.Context, options CreateServiceOptions
 			Env:                             cloneMap(options.Env),
 			Cwd:                             options.Cwd,
 			RuntimeClass:                    options.RuntimeClass,
+			Network:                         networkSpec(options.NetworkPolicy),
 			ExtensionCapabilityRequirements: extensionCapabilityRequirements(options.ExtensionCapabilities),
 			VolumeMounts:                    serviceVolumeMounts(options.Volumes),
 			ImageMounts:                     executionImageMounts(options.ImageMounts),
@@ -117,6 +119,13 @@ func (c *Client) CreateService(ctx context.Context, options CreateServiceOptions
 		return nil, mapRPCError(err, "create service", "")
 	}
 	return response.GetService(), nil
+}
+
+func networkSpec(policy *NetworkPolicy) *commonv1.NetworkSpec {
+	if policy == nil {
+		return nil
+	}
+	return &commonv1.NetworkSpec{EgressPolicy: policy.proto()}
 }
 
 // ExtensionCapability is an exact-match, DNS-qualified node extension fact.

--- a/sdk/go/go.mod
+++ b/sdk/go/go.mod
@@ -3,12 +3,12 @@ module github.com/cofy-x/axern/sdk/go
 go 1.25.12
 
 require (
+	golang.org/x/net v0.57.0
 	google.golang.org/grpc v1.82.1
 	google.golang.org/protobuf v1.36.11
 )
 
 require (
-	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260427160629-7cedc36a6bc4 // indirect

--- a/sdk/go/network_policy.go
+++ b/sdk/go/network_policy.go
@@ -1,0 +1,183 @@
+package axernsdk
+
+import (
+	"fmt"
+	"net/netip"
+	"sort"
+	"strings"
+
+	commonv1 "github.com/cofy-x/axern/sdk/go/gen/axern/control/common/v1"
+	"golang.org/x/net/idna"
+	"google.golang.org/protobuf/proto"
+)
+
+const maxNetworkPolicyRules = 256
+
+var forbiddenNetworkPolicyCIDRs = []netip.Prefix{
+	netip.MustParsePrefix("0.0.0.0/32"),
+	netip.MustParsePrefix("100.100.100.200/32"),
+	netip.MustParsePrefix("127.0.0.0/8"),
+	netip.MustParsePrefix("169.254.0.0/16"),
+	netip.MustParsePrefix("192.0.0.192/32"),
+	netip.MustParsePrefix("224.0.0.0/4"),
+	netip.MustParsePrefix("::/128"),
+	netip.MustParsePrefix("::1/128"),
+	netip.MustParsePrefix("fe80::/10"),
+	netip.MustParsePrefix("ff00::/8"),
+}
+
+type EgressProtocol string
+
+const (
+	EgressProtocolTCP EgressProtocol = "tcp"
+	EgressProtocolUDP EgressProtocol = "udp"
+)
+
+type PortRange struct {
+	Start uint32
+	End   uint32
+}
+
+type CIDRRule struct {
+	CIDR     string
+	Protocol EgressProtocol
+	Ports    []PortRange
+}
+
+type NetworkPolicy struct {
+	wire *commonv1.NetworkEgressPolicy
+}
+
+func NewStrictNetworkPolicy(domains []string, cidrRules []CIDRRule) (*NetworkPolicy, error) {
+	normalizedDomains, err := normalizePolicyDomains(domains)
+	if err != nil {
+		return nil, err
+	}
+	normalizedCIDRs, err := normalizePolicyCIDRs(cidrRules)
+	if err != nil {
+		return nil, err
+	}
+	if len(normalizedDomains)+len(normalizedCIDRs) > maxNetworkPolicyRules {
+		return nil, fmt.Errorf("network policy may contain at most %d rules", maxNetworkPolicyRules)
+	}
+	return &NetworkPolicy{wire: &commonv1.NetworkEgressPolicy{Policy: &commonv1.NetworkEgressPolicy_Strict{Strict: &commonv1.StrictEgressPolicy{AllowedDomains: normalizedDomains, AllowedCidrs: normalizedCIDRs}}}}, nil
+}
+
+func AllowDomainNetworkPolicy(domains ...string) (*NetworkPolicy, error) {
+	return NewStrictNetworkPolicy(domains, nil)
+}
+
+func DenyDNSNetworkPolicy(domains ...string) (*NetworkPolicy, error) {
+	normalized, err := normalizePolicyDomains(domains)
+	if err != nil {
+		return nil, err
+	}
+	if len(normalized) == 0 {
+		return nil, fmt.Errorf("deny DNS policy requires at least one domain")
+	}
+	return &NetworkPolicy{wire: &commonv1.NetworkEgressPolicy{Policy: &commonv1.NetworkEgressPolicy_DnsDeny{DnsDeny: &commonv1.DnsDenyPolicy{DeniedDomains: normalized}}}}, nil
+}
+
+func DenyAllNetworkPolicy() *NetworkPolicy {
+	policy, _ := NewStrictNetworkPolicy(nil, nil)
+	return policy
+}
+
+func (p *NetworkPolicy) proto() *commonv1.NetworkEgressPolicy {
+	if p == nil || p.wire == nil {
+		return nil
+	}
+	return proto.Clone(p.wire).(*commonv1.NetworkEgressPolicy)
+}
+
+func normalizePolicyDomains(values []string) ([]string, error) {
+	seen := map[string]struct{}{}
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		raw := strings.ToLower(strings.TrimSpace(value))
+		wildcard := strings.HasPrefix(raw, "*.")
+		if wildcard {
+			raw = strings.TrimPrefix(raw, "*.")
+		}
+		raw = strings.TrimSuffix(raw, ".")
+		if raw == "" || strings.ContainsAny(raw, "/:@?#*") {
+			return nil, fmt.Errorf("invalid domain rule %q", value)
+		}
+		if _, err := netip.ParseAddr(raw); err == nil {
+			return nil, fmt.Errorf("domain rule must not be an IP literal: %q", value)
+		}
+		ascii, err := idna.Lookup.ToASCII(raw)
+		if err != nil || len(ascii) > 253 {
+			return nil, fmt.Errorf("invalid domain rule %q", value)
+		}
+		for _, label := range strings.Split(ascii, ".") {
+			if label == "" || len(label) > 63 {
+				return nil, fmt.Errorf("invalid domain rule %q", value)
+			}
+		}
+		if wildcard {
+			ascii = "*." + ascii
+		}
+		if _, ok := seen[ascii]; !ok {
+			seen[ascii] = struct{}{}
+			result = append(result, ascii)
+		}
+	}
+	return result, nil
+}
+
+func normalizePolicyCIDRs(values []CIDRRule) ([]*commonv1.CIDREgressRule, error) {
+	seen := map[string]*commonv1.CIDREgressRule{}
+	for index, value := range values {
+		prefix, err := netip.ParsePrefix(strings.TrimSpace(value.CIDR))
+		if err != nil {
+			return nil, fmt.Errorf("CIDR rule %d: %w", index, err)
+		}
+		prefix = prefix.Masked()
+		for _, forbidden := range forbiddenNetworkPolicyCIDRs {
+			if prefix.Addr().BitLen() == forbidden.Addr().BitLen() && prefix.Bits() >= forbidden.Bits() && forbidden.Contains(prefix.Addr()) {
+				return nil, fmt.Errorf("CIDR rule %d targets a protected address range", index)
+			}
+		}
+		protocol := commonv1.EgressProtocol_EGRESS_PROTOCOL_TCP
+		if value.Protocol == EgressProtocolUDP {
+			protocol = commonv1.EgressProtocol_EGRESS_PROTOCOL_UDP
+		} else if value.Protocol != EgressProtocolTCP {
+			return nil, fmt.Errorf("CIDR rule %d protocol must be tcp or udp", index)
+		}
+		if len(value.Ports) == 0 {
+			return nil, fmt.Errorf("CIDR rule %d requires at least one port range", index)
+		}
+		ports := make([]*commonv1.PortRange, 0, len(value.Ports))
+		for _, value := range value.Ports {
+			end := value.End
+			if end == 0 {
+				end = value.Start
+			}
+			if value.Start == 0 || end < value.Start || end > 65535 {
+				return nil, fmt.Errorf("CIDR rule %d ports must be within 1..65535", index)
+			}
+			ports = append(ports, &commonv1.PortRange{Start: value.Start, End: end})
+		}
+		sort.Slice(ports, func(i, j int) bool {
+			return ports[i].GetStart() < ports[j].GetStart() || ports[i].GetStart() == ports[j].GetStart() && ports[i].GetEnd() < ports[j].GetEnd()
+		})
+		var keyBuilder strings.Builder
+		fmt.Fprintf(&keyBuilder, "%s|%d", prefix, protocol)
+		for _, port := range ports {
+			fmt.Fprintf(&keyBuilder, "|%d-%d", port.GetStart(), port.GetEnd())
+		}
+		key := keyBuilder.String()
+		seen[key] = &commonv1.CIDREgressRule{Cidr: prefix.String(), Protocol: protocol, Ports: ports}
+	}
+	keys := make([]string, 0, len(seen))
+	for key := range seen {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	result := make([]*commonv1.CIDREgressRule, 0, len(keys))
+	for _, key := range keys {
+		result = append(result, seen[key])
+	}
+	return result, nil
+}

--- a/sdk/go/network_policy_test.go
+++ b/sdk/go/network_policy_test.go
@@ -1,0 +1,47 @@
+package axernsdk
+
+import (
+	"testing"
+
+	commonv1 "github.com/cofy-x/axern/sdk/go/gen/axern/control/common/v1"
+)
+
+func TestDenyDNSNetworkPolicyNormalizesDomains(t *testing.T) {
+	policy, err := DenyDNSNetworkPolicy("GitHub.COM.", "github.com", "*.BÜCHER.example")
+	if err != nil {
+		t.Fatalf("DenyDNSNetworkPolicy() error = %v", err)
+	}
+	got := policy.proto().GetDnsDeny().GetDeniedDomains()
+	if len(got) != 2 || got[0] != "github.com" || got[1] != "*.xn--bcher-kva.example" {
+		t.Fatalf("domains = %v", got)
+	}
+}
+
+func TestNewStrictNetworkPolicyBuildsCIDRRules(t *testing.T) {
+	policy, err := NewStrictNetworkPolicy([]string{"example.com"}, []CIDRRule{{CIDR: "192.0.2.7/24", Protocol: EgressProtocolTCP, Ports: []PortRange{{Start: 22}, {Start: 8000, End: 8002}}}})
+	if err != nil {
+		t.Fatalf("NewStrictNetworkPolicy() error = %v", err)
+	}
+	rule := policy.proto().GetStrict().GetAllowedCidrs()[0]
+	if rule.GetCidr() != "192.0.2.0/24" || rule.GetProtocol() != commonv1.EgressProtocol_EGRESS_PROTOCOL_TCP || rule.GetPorts()[1].GetEnd() != 8002 {
+		t.Fatalf("rule = %+v", rule)
+	}
+}
+
+func TestDenyAllNetworkPolicyIsStrictEmpty(t *testing.T) {
+	strict := DenyAllNetworkPolicy().proto().GetStrict()
+	if strict == nil || len(strict.GetAllowedDomains()) != 0 || len(strict.GetAllowedCidrs()) != 0 {
+		t.Fatalf("strict = %+v", strict)
+	}
+}
+
+func TestNetworkPolicyRejectsInvalidRules(t *testing.T) {
+	for _, domain := range []string{"https://example.com", "example.com:443", "127.0.0.1", "foo.*.example"} {
+		if _, err := AllowDomainNetworkPolicy(domain); err == nil {
+			t.Fatalf("AllowDomainNetworkPolicy(%q) succeeded", domain)
+		}
+	}
+	if _, err := NewStrictNetworkPolicy(nil, []CIDRRule{{CIDR: "192.0.2.0/24", Protocol: EgressProtocolTCP, Ports: []PortRange{{Start: 0}}}}); err == nil {
+		t.Fatal("invalid port succeeded")
+	}
+}

--- a/sdk/go/sandbox.go
+++ b/sdk/go/sandbox.go
@@ -24,6 +24,7 @@ type SandboxOptions struct {
 	Env                     map[string]string
 	Cwd                     string
 	RuntimeClass            string
+	NetworkPolicy           *NetworkPolicy
 	ExtensionCapabilities   []ExtensionCapability
 	Volumes                 []VolumeMount
 	ImageMounts             []ImageMount
@@ -108,6 +109,7 @@ func (s *Sandbox) Start(ctx context.Context) error {
 		Env:                     s.options.Env,
 		Cwd:                     s.options.Cwd,
 		RuntimeClass:            s.options.RuntimeClass,
+		NetworkPolicy:           s.options.NetworkPolicy,
 		ExtensionCapabilities:   append([]ExtensionCapability(nil), s.options.ExtensionCapabilities...),
 		Volumes:                 s.options.Volumes,
 		ImageMounts:             s.options.ImageMounts,

--- a/sdk/go/sandbox_test.go
+++ b/sdk/go/sandbox_test.go
@@ -48,10 +48,15 @@ func TestSandboxStartExecFileClose(t *testing.T) {
 		t.Fatalf("new client: %v", err)
 	}
 	defer client.Close()
+	policy, err := AllowDomainNetworkPolicy("example.com")
+	if err != nil {
+		t.Fatalf("network policy: %v", err)
+	}
 
 	sandbox, err := NewSandbox(SandboxOptions{
 		Client:                client,
 		TemplateID:            "python311",
+		NetworkPolicy:         policy,
 		ReadyTimeout:          time.Second,
 		ExtensionCapabilities: []ExtensionCapability{{Name: "example.com/accelerator", Value: "v1"}},
 		Volumes: []VolumeMount{{
@@ -107,6 +112,9 @@ func TestSandboxStartExecFileClose(t *testing.T) {
 	}
 	if got := fake.createServiceRequest.GetConfig().GetExtensionCapabilityRequirements(); len(got) != 1 || got[0].GetCapability().GetName() != "example.com/accelerator" || got[0].GetCapability().GetValue() != "v1" {
 		t.Fatalf("unexpected extension capability requirements: %#v", got)
+	}
+	if got := fake.createServiceRequest.GetConfig().GetNetwork().GetEgressPolicy().GetStrict().GetAllowedDomains(); len(got) != 1 || got[0] != "example.com" {
+		t.Fatalf("unexpected network policy: %#v", got)
 	}
 
 	result, err := sandbox.Exec(ctx, "echo hello", ExecOptions{Check: true})

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -65,6 +65,39 @@ with Sandbox(client=client, image="docker.io/library/python:3.12-slim") as sandb
 client.close()
 ```
 
+## Network Policies
+
+Omitting `network_policy` preserves unrestricted v0.5 behavior. Strict
+policies are fail-closed; `deny_dns` only refuses matching traditional UDP/TCP
+DNS queries and does not block direct IP traffic, DoH, DoT, or already-resolved
+addresses.
+
+```python
+from axern_sdk import NetworkPolicy, Sandbox
+
+with Sandbox(
+    client=client,
+    image="docker.io/library/python:3.12-slim",
+    network_policy=NetworkPolicy.deny_dns(
+        "github.com",
+        "*.github.com",
+        "githubusercontent.com",
+        "*.githubusercontent.com",
+        "gitlab.com",
+        "*.gitlab.com",
+        "bitbucket.org",
+        "*.bitbucket.org",
+    ),
+) as sandbox:
+    print(sandbox.metadata.allocation_id)
+```
+
+`NetworkPolicy.allow_domains("example.com", "*.example.com")` is strict: only
+HTTP/HTTPS traffic whose controlled DNS result and HTTP Host or TLS SNI match is
+allowed. Use `NetworkPolicy.strict(..., cidr_rules=(CIDRRule(...),))` for
+explicit TCP/UDP CIDR and port grants, and `NetworkPolicy.deny_all()` for no
+egress.
+
 ## Volumes
 
 Use `VolumeMount` to attach Service V1 volumes to service-backed sandboxes.

--- a/sdk/python/src/axern_sdk/__init__.py
+++ b/sdk/python/src/axern_sdk/__init__.py
@@ -47,6 +47,7 @@ from axern_sdk.function import (
     load_function_spec,
 )
 from axern_sdk.models import HTTPProbe, ImageMount, SecretEnvVar, SecretFile, ServiceProbe, TCPProbe, VolumeMount
+from axern_sdk.network_policy import CIDRRule, NetworkPolicy, PortRange
 from axern_sdk.node import (
     AsyncNodeSandboxClient,
     AsyncProcessResult,
@@ -97,6 +98,7 @@ __all__ = [
     "AxernClient",
     "AxernContext",
     "CatalogClient",
+    "CIDRRule",
     "AsyncNodeSandboxClient",
     "AsyncProcessResult",
     "AsyncSandbox",
@@ -127,6 +129,8 @@ __all__ = [
     "HTTPProbe",
     "ImageMount",
     "NodeSandboxClient",
+    "NetworkPolicy",
+    "PortRange",
     "ProcessResult",
     "Sandbox",
     "SandboxFileInfo",

--- a/sdk/python/src/axern_sdk/async_client.py
+++ b/sdk/python/src/axern_sdk/async_client.py
@@ -31,6 +31,7 @@ from axern_sdk._internal.channel import async_control_channel
 from axern_sdk._internal.resources import ResourceQuantity
 from axern_sdk._internal.specs import environment_spec
 from axern_sdk.context import load_context
+from axern_sdk.network_policy import NetworkPolicy
 from axern_sdk.client import (
     DEFAULT_ENDPOINT,
     ServiceProbeInput,
@@ -363,6 +364,7 @@ class AsyncAxernClient:
         env: dict[str, str] | None = None,
         cwd: str = "",
         runtime_class: str = "",
+        network_policy: NetworkPolicy | None = None,
         request_cpu: ResourceQuantity = "",
         request_memory: ResourceQuantity = "",
         request_ephemeral_storage: ResourceQuantity = "",
@@ -390,6 +392,11 @@ class AsyncAxernClient:
                     env=dict(env or {}),
                     cwd=cwd,
                     runtime_class=runtime_class,
+                    network=(
+                        common_pb2.NetworkSpec(egress_policy=network_policy._to_proto())
+                        if network_policy is not None
+                        else None
+                    ),
                     resources=_resource_spec(
                         request_cpu=request_cpu,
                         request_memory=request_memory,

--- a/sdk/python/src/axern_sdk/client.py
+++ b/sdk/python/src/axern_sdk/client.py
@@ -33,6 +33,7 @@ from axern_sdk._internal.resources import ResourceQuantity, cpu_milli, memory_by
 from axern_sdk._internal.specs import environment_spec
 from axern_sdk.context import load_context
 from axern_sdk.models import HTTPProbe, ServiceProbe, TCPProbe, VolumeMount
+from axern_sdk.network_policy import NetworkPolicy
 from axern_sdk.tunnel.config import _GatewayTransport
 
 
@@ -440,6 +441,7 @@ class AxernClient:
         env: dict[str, str] | None = None,
         cwd: str = "",
         runtime_class: str = "",
+        network_policy: NetworkPolicy | None = None,
         request_cpu: ResourceQuantity = "",
         request_memory: ResourceQuantity = "",
         request_ephemeral_storage: ResourceQuantity = "",
@@ -467,6 +469,11 @@ class AxernClient:
                     env=dict(env or {}),
                     cwd=cwd,
                     runtime_class=runtime_class,
+                    network=(
+                        common_pb2.NetworkSpec(egress_policy=network_policy._to_proto())
+                        if network_policy is not None
+                        else None
+                    ),
                     resources=_resource_spec(
                         request_cpu=request_cpu,
                         request_memory=request_memory,

--- a/sdk/python/src/axern_sdk/network_policy.py
+++ b/sdk/python/src/axern_sdk/network_policy.py
@@ -1,0 +1,158 @@
+"""Public sandbox egress policy models."""
+
+from __future__ import annotations
+
+import ipaddress
+from dataclasses import dataclass
+from typing import Literal
+
+from axern.control.common.v1 import common_pb2
+
+_MAX_RULES = 256
+_FORBIDDEN_IPV4 = (
+    ipaddress.IPv4Network("0.0.0.0/32"),
+    ipaddress.IPv4Network("100.100.100.200/32"),
+    ipaddress.IPv4Network("127.0.0.0/8"),
+    ipaddress.IPv4Network("169.254.0.0/16"),
+    ipaddress.IPv4Network("192.0.0.192/32"),
+    ipaddress.IPv4Network("224.0.0.0/4"),
+)
+_FORBIDDEN_IPV6 = (
+    ipaddress.IPv6Network("::/128"),
+    ipaddress.IPv6Network("::1/128"),
+    ipaddress.IPv6Network("fe80::/10"),
+    ipaddress.IPv6Network("ff00::/8"),
+)
+
+
+@dataclass(frozen=True, slots=True)
+class PortRange:
+    """An inclusive TCP or UDP destination port range."""
+
+    start: int
+    end: int | None = None
+
+    def __post_init__(self) -> None:
+        end = self.start if self.end is None else self.end
+        if not 1 <= self.start <= 65535 or not self.start <= end <= 65535:
+            raise ValueError("ports must be an inclusive range within 1..65535")
+        object.__setattr__(self, "end", end)
+
+
+@dataclass(frozen=True, slots=True)
+class CIDRRule:
+    """An explicit non-HTTP CIDR, protocol, and destination-port grant."""
+
+    cidr: str
+    protocol: Literal["tcp", "udp"]
+    ports: tuple[PortRange, ...]
+
+    def __post_init__(self) -> None:
+        try:
+            network = ipaddress.ip_network(self.cidr.strip(), strict=False)
+        except ValueError as exc:
+            raise ValueError(f"invalid CIDR {self.cidr!r}") from exc
+        protected = (
+            any(network.subnet_of(forbidden) for forbidden in _FORBIDDEN_IPV4)
+            if isinstance(network, ipaddress.IPv4Network)
+            else any(network.subnet_of(forbidden) for forbidden in _FORBIDDEN_IPV6)
+        )
+        if protected:
+            raise ValueError(f"CIDR {self.cidr!r} targets a protected address range")
+        protocol = self.protocol.lower()
+        if protocol not in {"tcp", "udp"}:
+            raise ValueError("CIDR protocol must be 'tcp' or 'udp'")
+        if not self.ports:
+            raise ValueError("CIDR rule requires at least one port range")
+        ports = tuple(dict.fromkeys(self.ports))
+        object.__setattr__(self, "cidr", network.with_prefixlen)
+        object.__setattr__(self, "protocol", protocol)
+        object.__setattr__(self, "ports", ports)
+
+
+class NetworkPolicy:
+    """A normalized strict or DNS-only sandbox egress policy."""
+
+    __slots__ = ("_cidr_rules", "_domains", "_mode")
+
+    def __init__(self, mode: Literal["strict", "dns_deny"], domains: tuple[str, ...], cidr_rules: tuple[CIDRRule, ...] = ()) -> None:
+        if len(domains) + len(cidr_rules) > _MAX_RULES:
+            raise ValueError(f"network policy may contain at most {_MAX_RULES} rules")
+        self._mode = mode
+        self._domains = domains
+        self._cidr_rules = cidr_rules
+
+    @classmethod
+    def strict(cls, *domains: str, cidr_rules: tuple[CIDRRule, ...] = ()) -> "NetworkPolicy":
+        return cls("strict", _normalize_domains(domains), _dedupe_cidrs(cidr_rules))
+
+    @classmethod
+    def allow_domains(cls, *domains: str) -> "NetworkPolicy":
+        return cls.strict(*domains)
+
+    @classmethod
+    def deny_dns(cls, *domains: str) -> "NetworkPolicy":
+        normalized = _normalize_domains(domains)
+        if not normalized:
+            raise ValueError("deny_dns requires at least one domain")
+        return cls("dns_deny", normalized)
+
+    @classmethod
+    def deny_all(cls) -> "NetworkPolicy":
+        return cls.strict()
+
+    def _to_proto(self) -> common_pb2.NetworkEgressPolicy:
+        if self._mode == "dns_deny":
+            return common_pb2.NetworkEgressPolicy(dns_deny=common_pb2.DnsDenyPolicy(denied_domains=self._domains))
+        return common_pb2.NetworkEgressPolicy(
+            strict=common_pb2.StrictEgressPolicy(
+                allowed_domains=self._domains,
+                allowed_cidrs=[
+                    common_pb2.CIDREgressRule(
+                        cidr=rule.cidr,
+                        protocol=(
+                            common_pb2.EGRESS_PROTOCOL_TCP
+                            if rule.protocol == "tcp"
+                            else common_pb2.EGRESS_PROTOCOL_UDP
+                        ),
+                        ports=[common_pb2.PortRange(start=port.start, end=port.end) for port in rule.ports],
+                    )
+                    for rule in self._cidr_rules
+                ],
+            )
+        )
+
+
+def _normalize_domains(values: tuple[str, ...]) -> tuple[str, ...]:
+    result: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        raw = value.strip().lower()
+        wildcard = raw.startswith("*.")
+        if wildcard:
+            raw = raw[2:]
+        raw = raw.rstrip(".")
+        if not raw or any(char in raw for char in "/:@?#") or "*" in raw:
+            raise ValueError(f"invalid domain rule {value!r}")
+        try:
+            if ipaddress.ip_address(raw):
+                raise ValueError(f"domain rule must not be an IP literal: {value!r}")
+        except ValueError as exc:
+            if "must not be" in str(exc):
+                raise
+        try:
+            normalized = raw.encode("idna").decode("ascii").lower()
+        except UnicodeError as exc:
+            raise ValueError(f"invalid domain rule {value!r}") from exc
+        labels = normalized.split(".")
+        if len(normalized.encode("ascii")) > 253 or any(not label or len(label) > 63 for label in labels):
+            raise ValueError(f"invalid domain rule {value!r}")
+        normalized = f"*.{normalized}" if wildcard else normalized
+        if normalized not in seen:
+            seen.add(normalized)
+            result.append(normalized)
+    return tuple(result)
+
+
+def _dedupe_cidrs(values: tuple[CIDRRule, ...]) -> tuple[CIDRRule, ...]:
+    return tuple(dict.fromkeys(values))

--- a/sdk/python/src/axern_sdk/sandbox/__init__.py
+++ b/sdk/python/src/axern_sdk/sandbox/__init__.py
@@ -20,6 +20,7 @@ from axern_sdk.node import (
     SandboxProcess,
 )
 from axern_sdk.sandbox.async_sandbox import AsyncSandbox
+from axern_sdk.network_policy import CIDRRule, NetworkPolicy, PortRange
 from axern_sdk.sandbox.sandbox import Sandbox
 from axern_sdk.sandbox.types import SandboxMetadata, SandboxState
 
@@ -27,6 +28,7 @@ __all__ = [
     "AsyncSandbox",
     "AsyncSandboxProcess",
     "BrowserStatus",
+    "CIDRRule",
     "CapabilityDependencyStatus",
     "CapabilityProviderStatus",
     "CapabilityProviderSummary",
@@ -38,6 +40,8 @@ __all__ = [
     "ExecResult",
     "ExecStreamEvent",
     "NodeSandboxClient",
+    "NetworkPolicy",
+    "PortRange",
     "ProcessResult",
     "Sandbox",
     "SandboxFileInfo",

--- a/sdk/python/src/axern_sdk/sandbox/async_sandbox.py
+++ b/sdk/python/src/axern_sdk/sandbox/async_sandbox.py
@@ -25,6 +25,7 @@ from axern_sdk.sandbox.async_computer_use import AsyncSandboxComputerUseMixin
 from axern_sdk.sandbox.async_files import AsyncSandboxFileMixin
 from axern_sdk.sandbox.async_lifecycle import wait_ready_replica, wait_service_deleted
 from axern_sdk.sandbox.async_renewal import AsyncTunnelRenewal
+from axern_sdk.network_policy import NetworkPolicy
 from axern_sdk.sandbox.types import DEFAULT_SANDBOX_ARGV, SandboxMetadata, SandboxState, _validate_source
 from axern_sdk.tunnel import ConnectorConfig, TunnelConnector
 
@@ -45,6 +46,7 @@ class AsyncSandbox(AsyncSandboxCapabilityMixin, AsyncSandboxBrowserMixin, AsyncS
         env: dict[str, str] | None = None,
         cwd: str = "",
         runtime_class: str = "",
+        network_policy: NetworkPolicy | None = None,
         request_cpu: ResourceQuantity = "",
         request_memory: ResourceQuantity = "",
         request_ephemeral_storage: ResourceQuantity = "",
@@ -75,6 +77,7 @@ class AsyncSandbox(AsyncSandboxCapabilityMixin, AsyncSandboxBrowserMixin, AsyncS
         self._env = dict(env or {})
         self._cwd = cwd
         self._runtime_class = runtime_class
+        self._network_policy = network_policy
         self._request_cpu = request_cpu
         self._request_memory = request_memory
         self._request_ephemeral_storage = request_ephemeral_storage
@@ -173,6 +176,7 @@ class AsyncSandbox(AsyncSandboxCapabilityMixin, AsyncSandboxBrowserMixin, AsyncS
                 env=self._env,
                 cwd=self._cwd,
                 runtime_class=self._runtime_class,
+                network_policy=self._network_policy,
                 request_cpu=self._request_cpu,
                 request_memory=self._request_memory,
                 request_ephemeral_storage=self._request_ephemeral_storage,

--- a/sdk/python/src/axern_sdk/sandbox/sandbox.py
+++ b/sdk/python/src/axern_sdk/sandbox/sandbox.py
@@ -23,6 +23,7 @@ from axern_sdk.sandbox.capabilities import SandboxCapabilityMixin
 from axern_sdk.sandbox.computer_use import SandboxComputerUseMixin
 from axern_sdk.sandbox.files import SandboxFileMixin
 from axern_sdk.sandbox.lifecycle import wait_ready_replica, wait_service_deleted
+from axern_sdk.network_policy import NetworkPolicy
 from axern_sdk.sandbox.renewal import TunnelRenewal
 from axern_sdk.sandbox.types import DEFAULT_SANDBOX_ARGV, SandboxMetadata, SandboxState, _validate_source
 from axern_sdk.tunnel import ConnectorConfig, TunnelConnector
@@ -44,6 +45,7 @@ class Sandbox(SandboxCapabilityMixin, SandboxBrowserMixin, SandboxComputerUseMix
         env: dict[str, str] | None = None,
         cwd: str = "",
         runtime_class: str = "",
+        network_policy: NetworkPolicy | None = None,
         request_cpu: ResourceQuantity = "",
         request_memory: ResourceQuantity = "",
         request_ephemeral_storage: ResourceQuantity = "",
@@ -74,6 +76,7 @@ class Sandbox(SandboxCapabilityMixin, SandboxBrowserMixin, SandboxComputerUseMix
         self._env = dict(env or {})
         self._cwd = cwd
         self._runtime_class = runtime_class
+        self._network_policy = network_policy
         self._request_cpu = request_cpu
         self._request_memory = request_memory
         self._request_ephemeral_storage = request_ephemeral_storage
@@ -173,6 +176,7 @@ class Sandbox(SandboxCapabilityMixin, SandboxBrowserMixin, SandboxComputerUseMix
                 env=self._env,
                 cwd=self._cwd,
                 runtime_class=self._runtime_class,
+                network_policy=self._network_policy,
                 request_cpu=self._request_cpu,
                 request_memory=self._request_memory,
                 request_ephemeral_storage=self._request_ephemeral_storage,

--- a/sdk/python/tests/test_contract_v1.py
+++ b/sdk/python/tests/test_contract_v1.py
@@ -22,6 +22,7 @@ from axern_sdk.errors import (
     SandboxValidationError,
 )
 from axern_sdk.sandbox import Sandbox
+from axern_sdk import CIDRRule, NetworkPolicy, PortRange
 from axern_sdk.sandbox.types import _validate_source
 
 
@@ -137,6 +138,25 @@ class ContractV1Test(unittest.TestCase):
         self.assertIn("extension_capabilities", parameters)
         self.assertIn("upstream", parameters)
         self.assertIn("remote_port", parameters)
+
+    def test_network_policy_contract(self) -> None:
+        contract = load("network_policies.json")
+        domains = contract["domains"]
+        wire = NetworkPolicy.deny_dns(*domains["input"])._to_proto()
+        self.assertEqual(list(wire.dns_deny.denied_domains), domains["normalized"])
+        cidr = contract["cidr"]
+        rule = CIDRRule(
+            cidr["cidr"],
+            cidr["protocol"],
+            tuple(PortRange(item["start"], item["end"]) for item in cidr["ports"]),
+        )
+        self.assertEqual(NetworkPolicy.strict(cidr_rules=(rule,))._to_proto().strict.allowed_cidrs[0].cidr, cidr["cidr"])
+        for value in contract["invalid_domains"]:
+            with self.assertRaises(ValueError):
+                NetworkPolicy.allow_domains(value)
+        for value in contract["invalid_cidrs"]:
+            with self.assertRaises(ValueError):
+                CIDRRule(value, "tcp", (PortRange(443),))
 
 
 def load(name: str) -> dict[str, object]:

--- a/sdk/python/tests/test_network_policy.py
+++ b/sdk/python/tests/test_network_policy.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import unittest
+
+from axern.control.common.v1 import common_pb2
+from axern.control.service.v1 import service_pb2, service_types_pb2
+from axern_sdk import AxernClient, CIDRRule, NetworkPolicy, PortRange
+
+
+class NetworkPolicyTest(unittest.TestCase):
+    def test_deny_dns_normalizes_and_deduplicates_domains(self) -> None:
+        policy = NetworkPolicy.deny_dns("GitHub.COM.", "github.com", "*.BÜCHER.example")
+        wire = policy._to_proto()
+        self.assertEqual(list(wire.dns_deny.denied_domains), ["github.com", "*.xn--bcher-kva.example"])
+
+    def test_strict_builds_domain_and_cidr_grants(self) -> None:
+        policy = NetworkPolicy.strict(
+            "example.com",
+            cidr_rules=(CIDRRule("192.0.2.7/24", "tcp", (PortRange(22), PortRange(8000, 8002))),),
+        )
+        wire = policy._to_proto()
+        self.assertEqual(list(wire.strict.allowed_domains), ["example.com"])
+        self.assertEqual(wire.strict.allowed_cidrs[0].cidr, "192.0.2.0/24")
+        self.assertEqual(wire.strict.allowed_cidrs[0].protocol, common_pb2.EGRESS_PROTOCOL_TCP)
+        self.assertEqual(wire.strict.allowed_cidrs[0].ports[1].end, 8002)
+
+    def test_deny_all_is_strict_empty(self) -> None:
+        wire = NetworkPolicy.deny_all()._to_proto()
+        self.assertEqual(wire.WhichOneof("policy"), "strict")
+        self.assertEqual(len(wire.strict.allowed_domains), 0)
+
+    def test_rejects_invalid_domains_and_ports(self) -> None:
+        for value in ("https://example.com", "example.com:443", "127.0.0.1", "foo.*.example"):
+            with self.subTest(value=value), self.assertRaises(ValueError):
+                NetworkPolicy.allow_domains(value)
+        with self.assertRaises(ValueError):
+            PortRange(0)
+        with self.assertRaises(ValueError):
+            CIDRRule("not-a-cidr", "tcp", (PortRange(22),))
+
+    def test_create_service_serializes_network_policy(self) -> None:
+        class ServiceStub:
+            request = None
+
+            def CreateService(self, request, timeout=None):
+                del timeout
+                self.request = request
+                return service_pb2.CreateServiceResponse(service=service_types_pb2.Service(id="svc-1"))
+
+        client = AxernClient.__new__(AxernClient)
+        stub = ServiceStub()
+        client.services = stub
+        client.create_service(environment_id="env-1", network_policy=NetworkPolicy.allow_domains("example.com"))
+
+        self.assertEqual(list(stub.request.config.network.egress_policy.strict.allowed_domains), ["example.com"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -68,6 +68,32 @@ try {
 }
 ```
 
+## Network Policies
+
+Omitting `networkPolicy` keeps unrestricted v0.5 behavior. Strict policies are
+fail-closed; `denyDns` only refuses matching traditional UDP/TCP DNS queries and
+does not block direct IP traffic, DoH, DoT, or already-resolved addresses.
+
+```ts
+import { NetworkPolicy, Sandbox } from "@cofy-x/axern-sdk";
+
+const sandbox = await new Sandbox({
+  client,
+  image: "docker.io/library/python:3.12-slim",
+  networkPolicy: NetworkPolicy.denyDns(
+    "github.com",
+    "*.github.com",
+    "githubusercontent.com",
+    "*.githubusercontent.com",
+  ),
+}).start();
+```
+
+`NetworkPolicy.allowDomains("example.com", "*.example.com")` allows only
+strict HTTP/HTTPS destinations validated by DNS plus HTTP Host or TLS SNI.
+`NetworkPolicy.strict({ cidrRules: [...] })` adds explicit TCP/UDP CIDR and port
+grants; `NetworkPolicy.denyAll()` allows no egress.
+
 Run a tool from a separate image with `execImage` or `processImage`. OCI and
 Nydus refs use the same image field. When `mounts` is omitted, the SDK requests
 `/workspace -> /workspace`; pass `mounts: []` for no shared paths. Use

--- a/sdk/typescript/src/client/index.ts
+++ b/sdk/typescript/src/client/index.ts
@@ -13,6 +13,7 @@ import { serviceConstructor, unary } from "../generated/proto.js";
 import { NodeSandboxClient } from "../node/client.js";
 import { buildResourceSpec } from "../resources.js";
 import type { ResourceQuantity } from "../resources.js";
+import type { NetworkPolicy } from "../network-policy.js";
 import { TunnelControlClient } from "../tunnel/control.js";
 import type { VolumeMount } from "../types.js";
 import type { GatewayTransportOptions } from "../tunnel/relay.js";
@@ -44,6 +45,7 @@ export interface CreateServiceOptions {
   env?: Record<string, string>;
   cwd?: string;
   runtimeClass?: string;
+  networkPolicy?: NetworkPolicy;
   extensionCapabilities?: readonly ExtensionCapability[];
   volumes?: readonly VolumeMount[];
   requestCpu?: ResourceQuantity;
@@ -271,6 +273,9 @@ export class AxernClient {
             env: options.env ?? {},
             cwd: options.cwd ?? "",
             runtime_class: options.runtimeClass ?? "",
+            ...(options.networkPolicy === undefined
+              ? {}
+              : { network: { egress_policy: options.networkPolicy.toWire() } }),
             extension_capability_requirements: (options.extensionCapabilities ?? []).map((capability) => ({
               capability: { name: capability.name, value: capability.value ?? "" },
             })),

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -33,6 +33,8 @@ export { SandboxProcess } from "./node/process.js";
 export type { ResourceQuantity } from "./resources.js";
 export { Sandbox } from "./sandbox/index.js";
 export type { SandboxMetadata, SandboxOptions, SandboxState } from "./sandbox/index.js";
+export { NetworkPolicy, cidrRule, portRange } from "./network-policy.js";
+export type { CIDRRule, PortRange, StrictNetworkPolicyOptions } from "./network-policy.js";
 export type {
   ChmodOptions,
   CapabilityDependencyStatus,

--- a/sdk/typescript/src/network-policy.ts
+++ b/sdk/typescript/src/network-policy.ts
@@ -1,0 +1,158 @@
+/**
+ * @license
+ * Copyright 2026 cofy-x
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { isIP } from "node:net";
+import { domainToASCII } from "node:url";
+
+export interface PortRange {
+  readonly start: number;
+  readonly end: number;
+}
+
+export interface CIDRRule {
+  readonly cidr: string;
+  readonly protocol: "tcp" | "udp";
+  readonly ports: readonly PortRange[];
+}
+
+export interface StrictNetworkPolicyOptions {
+  readonly domains?: readonly string[];
+  readonly cidrRules?: readonly CIDRRule[];
+}
+
+type NetworkPolicyWire =
+  | { strict: { allowed_domains: string[]; allowed_cidrs: Record<string, unknown>[] } }
+  | { dns_deny: { denied_domains: string[] } };
+
+const maxRules = 256;
+
+export class NetworkPolicy {
+  private constructor(private readonly wire: NetworkPolicyWire) {}
+
+  static strict(options: StrictNetworkPolicyOptions = {}): NetworkPolicy {
+    const domains = normalizeDomains(options.domains ?? []);
+    const cidrRules = normalizeCIDRRules(options.cidrRules ?? []);
+    if (domains.length + cidrRules.length > maxRules) {
+      throw new RangeError(`network policy may contain at most ${maxRules} rules`);
+    }
+    return new NetworkPolicy({
+      strict: {
+        allowed_domains: domains,
+        allowed_cidrs: cidrRules.map((rule) => ({
+          cidr: rule.cidr,
+          protocol: rule.protocol === "tcp" ? 1 : 2,
+          ports: rule.ports.map((port) => ({ start: port.start, end: port.end })),
+        })),
+      },
+    });
+  }
+
+  static allowDomains(...domains: string[]): NetworkPolicy {
+    return NetworkPolicy.strict({ domains });
+  }
+
+  static denyDns(...domains: string[]): NetworkPolicy {
+    const normalized = normalizeDomains(domains);
+    if (normalized.length === 0) throw new RangeError("denyDns requires at least one domain");
+    return new NetworkPolicy({ dns_deny: { denied_domains: normalized } });
+  }
+
+  static denyAll(): NetworkPolicy {
+    return NetworkPolicy.strict();
+  }
+
+  /** @internal */
+  toWire(): NetworkPolicyWire {
+    return structuredClone(this.wire);
+  }
+}
+
+export function portRange(start: number, end: number = start): PortRange {
+  if (!Number.isInteger(start) || !Number.isInteger(end) || start < 1 || end < start || end > 65535) {
+    throw new RangeError("ports must be an inclusive range within 1..65535");
+  }
+  return Object.freeze({ start, end });
+}
+
+export function cidrRule(cidr: string, protocol: "tcp" | "udp", ...ports: PortRange[]): CIDRRule {
+  return normalizeCIDRRule({ cidr, protocol, ports });
+}
+
+function normalizeDomains(values: readonly string[]): string[] {
+  const result: string[] = [];
+  const seen = new Set<string>();
+  for (const value of values) {
+    let raw = value.trim().toLowerCase();
+    const wildcard = raw.startsWith("*.");
+    if (wildcard) raw = raw.slice(2);
+    raw = raw.replace(/\.+$/, "");
+    if (raw === "" || /[/:@?#*]/u.test(raw) || isIP(raw) !== 0) {
+      throw new TypeError(`invalid domain rule ${JSON.stringify(value)}`);
+    }
+    const ascii = domainToASCII(raw).toLowerCase();
+    const labels = ascii.split(".");
+    if (ascii === "" || Buffer.byteLength(ascii, "ascii") > 253 || labels.some((label) => label === "" || label.length > 63)) {
+      throw new TypeError(`invalid domain rule ${JSON.stringify(value)}`);
+    }
+    const normalized = wildcard ? `*.${ascii}` : ascii;
+    if (!seen.has(normalized)) {
+      seen.add(normalized);
+      result.push(normalized);
+    }
+  }
+  return result;
+}
+
+function normalizeCIDRRules(values: readonly CIDRRule[]): CIDRRule[] {
+  const result: CIDRRule[] = [];
+  const seen = new Set<string>();
+  for (const value of values) {
+    const rule = normalizeCIDRRule(value);
+    const key = JSON.stringify(rule);
+    if (!seen.has(key)) {
+      seen.add(key);
+      result.push(rule);
+    }
+  }
+  return result;
+}
+
+function normalizeCIDRRule(value: CIDRRule): CIDRRule {
+  const cidr = value.cidr.trim();
+  const separator = cidr.lastIndexOf("/");
+  const address = separator < 0 ? "" : cidr.slice(0, separator);
+  const prefix = separator < 0 ? -1 : Number(cidr.slice(separator + 1));
+  const family = isIP(address);
+  if ((family !== 4 && family !== 6) || !Number.isInteger(prefix) || prefix < 0 || prefix > (family === 4 ? 32 : 128)) {
+    throw new TypeError(`invalid CIDR ${JSON.stringify(value.cidr)}`);
+  }
+  if (isProtectedCIDR(address, prefix, family)) {
+    throw new TypeError(`CIDR ${JSON.stringify(value.cidr)} targets a protected address range`);
+  }
+  if (value.protocol !== "tcp" && value.protocol !== "udp") throw new TypeError("CIDR protocol must be tcp or udp");
+  if (value.ports.length === 0) throw new RangeError("CIDR rule requires at least one port range");
+  const ports = value.ports.map((port) => portRange(port.start, port.end));
+  return Object.freeze({ cidr, protocol: value.protocol, ports: Object.freeze(ports) });
+}
+
+function isProtectedCIDR(address: string, prefix: number, family: number): boolean {
+  if (family === 4) {
+    const value = address.split(".").reduce((result, octet) => (result << 8n) | BigInt(octet), 0n);
+    const protectedRanges: readonly [bigint, number][] = [
+      [0n, 32],
+      [1684301000n, 32], // 100.100.100.200
+      [2130706432n, 8], // 127.0.0.0
+      [2851995648n, 16], // 169.254.0.0
+      [3221225664n, 32], // 192.0.0.192
+      [3758096384n, 4], // 224.0.0.0
+    ];
+    return protectedRanges.some(([base, bits]) => prefix >= bits && (value >> BigInt(32 - bits)) === (base >> BigInt(32 - bits)));
+  }
+  const canonical = new URL(`http://[${address}]/`).hostname.slice(1, -1).toLowerCase();
+  if (prefix >= 128 && (canonical === "::" || canonical === "::1")) return true;
+  const first = Number.parseInt(canonical.split(":", 1)[0] || "0", 16);
+  return (prefix >= 10 && first >= 0xfe80 && first <= 0xfebf) || (prefix >= 8 && first >= 0xff00 && first <= 0xffff);
+}

--- a/sdk/typescript/src/sandbox/index.ts
+++ b/sdk/typescript/src/sandbox/index.ts
@@ -10,6 +10,7 @@ import { SandboxStateError } from "../errors/index.js";
 import type { NodeSandboxClient } from "../node/client.js";
 import type { SandboxProcess } from "../node/process.js";
 import type { ResourceQuantity } from "../resources.js";
+import type { NetworkPolicy } from "../network-policy.js";
 import { startTunnelRuntime, tunnelMetadata } from "../tunnel/runtime.js";
 import type { TunnelRuntime } from "../tunnel/types.js";
 import type {
@@ -54,6 +55,7 @@ export interface SandboxOptions {
   env?: Record<string, string>;
   cwd?: string;
   runtimeClass?: string;
+  networkPolicy?: NetworkPolicy;
   extensionCapabilities?: readonly ExtensionCapability[];
   volumes?: readonly VolumeMount[];
   requestCpu?: ResourceQuantity;
@@ -142,6 +144,7 @@ export class Sandbox {
         env: this.options.env,
         cwd: this.options.cwd,
         runtimeClass: this.options.runtimeClass,
+        networkPolicy: this.options.networkPolicy,
         extensionCapabilities: this.options.extensionCapabilities,
         volumes: this.options.volumes,
         requestCpu: this.options.requestCpu,

--- a/sdk/typescript/tests/contract_v1.test.ts
+++ b/sdk/typescript/tests/contract_v1.test.ts
@@ -26,6 +26,7 @@ import { buildResourceSpec } from "../src/resources.js";
 import { validateSandboxOptions } from "../src/sandbox/lifecycle.js";
 import { Sandbox } from "../src/sandbox/index.js";
 import type { SandboxOptions } from "../src/sandbox/index.js";
+import { NetworkPolicy, cidrRule, portRange } from "../src/network-policy.js";
 
 interface QuantityCase { input: string; value: number }
 interface ErrorCase { code: string; number: number; class: string; retryable: boolean }
@@ -135,6 +136,22 @@ test("shared common core surface", () => {
     computer_use_mouse: "computerUseMouse",
     computer_use_keyboard: "computerUseKeyboard",
   });
+});
+
+test("shared network policy contract", () => {
+  const contract = load<{
+    domains: { input: string[]; normalized: string[] };
+    cidr: { cidr: string; protocol: "tcp" | "udp"; ports: { start: number; end: number }[] };
+    invalid_domains: string[];
+    invalid_cidrs: string[];
+  }>("network_policies.json");
+  assert.deepEqual(NetworkPolicy.denyDns(...contract.domains.input).toWire(), {
+    dns_deny: { denied_domains: contract.domains.normalized },
+  });
+  const rule = cidrRule(contract.cidr.cidr, contract.cidr.protocol, ...contract.cidr.ports.map((item) => portRange(item.start, item.end)));
+  assert.equal((NetworkPolicy.strict({ cidrRules: [rule] }).toWire() as { strict: { allowed_cidrs: { cidr: string }[] } }).strict.allowed_cidrs[0]?.cidr, contract.cidr.cidr);
+  for (const value of contract.invalid_domains) assert.throws(() => NetworkPolicy.allowDomains(value));
+  for (const value of contract.invalid_cidrs) assert.throws(() => cidrRule(value, "tcp", portRange(443)));
 });
 
 function load<T>(name: string): T {

--- a/sdk/typescript/tests/network_policy.test.ts
+++ b/sdk/typescript/tests/network_policy.test.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright 2026 cofy-x
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { NetworkPolicy, cidrRule, portRange } from "../src/index.js";
+
+test("denyDns normalizes and deduplicates domains", () => {
+  assert.deepEqual(NetworkPolicy.denyDns("GitHub.COM.", "github.com", "*.BÜCHER.example").toWire(), {
+    dns_deny: { denied_domains: ["github.com", "*.xn--bcher-kva.example"] },
+  });
+});
+
+test("strict serializes domain and CIDR grants", () => {
+  assert.deepEqual(
+    NetworkPolicy.strict({
+      domains: ["example.com"],
+      cidrRules: [cidrRule("192.0.2.0/24", "tcp", portRange(22), portRange(8000, 8002))],
+    }).toWire(),
+    {
+      strict: {
+        allowed_domains: ["example.com"],
+        allowed_cidrs: [{
+          cidr: "192.0.2.0/24",
+          protocol: 1,
+          ports: [{ start: 22, end: 22 }, { start: 8000, end: 8002 }],
+        }],
+      },
+    },
+  );
+});
+
+test("denyAll is strict empty and invalid rules fail locally", () => {
+  assert.deepEqual(NetworkPolicy.denyAll().toWire(), { strict: { allowed_domains: [], allowed_cidrs: [] } });
+  assert.throws(() => NetworkPolicy.allowDomains("https://example.com"));
+  assert.throws(() => NetworkPolicy.allowDomains("127.0.0.1"));
+  assert.throws(() => portRange(0));
+  assert.throws(() => cidrRule("not-a-cidr", "tcp", portRange(22)));
+});

--- a/sdk/typescript/tests/sandbox.test.ts
+++ b/sdk/typescript/tests/sandbox.test.ts
@@ -10,6 +10,7 @@ import test from "node:test";
 import { AxernClient } from "../src/client/index.js";
 import { SandboxValidationError } from "../src/errors/index.js";
 import { Sandbox } from "../src/sandbox/index.js";
+import { NetworkPolicy } from "../src/network-policy.js";
 
 test("sandbox creates image-backed environment and delegates exec", async () => {
   const calls: string[] = [];
@@ -55,9 +56,11 @@ test("sandbox creates image-backed environment and delegates exec", async () => 
     close() {},
   } as unknown as AxernClient;
 
+  const networkPolicy = NetworkPolicy.allowDomains("example.com");
   const sandbox = new Sandbox({
     client: fakeClient,
     image: "python:3.12-slim",
+    networkPolicy,
     requestCpu: 1,
     requestMemory: 512,
     limitCpu: "1500m",
@@ -83,6 +86,7 @@ test("sandbox creates image-backed environment and delegates exec", async () => 
   assert.equal(serviceOptions?.limitMemory, "1GiB");
   assert.deepEqual(serviceOptions?.extensionCapabilities, [{ name: "example.com/accelerator", value: "v1" }]);
   assert.deepEqual(serviceOptions?.volumes, [{ name: "workspace", target: "/workspace", readonly: true, options: ["rbind"] }]);
+  assert.equal(serviceOptions?.networkPolicy, networkPolicy);
 });
 
 test("client rejects negative service resource values before RPC", async () => {


### PR DESCRIPTION
## Summary

- expose strict, domain allowlist, DNS deny, and deny-all policies in Python, TypeScript, and Go
- serialize policies through Sandbox and CreateService APIs with shared normalization and validation contracts
- verify packaged artifacts can construct network policies and document the strict vs DNS-only security boundary

## Verification

- `make sdk-contract-verify`
- `make proto-generated-check`
- `make release-check`
- `make open-source-check`
- `make lint`
- `make build`
- `make test`
- `git diff HEAD --check`

Closes #82
Refs #78