### PR TITLE
fix(local): cover fresh capability certification

### DIFF
--- a/apps/cli/internal/commands/local/command.go
+++ b/apps/cli/internal/commands/local/command.go
@@ -56,16 +56,26 @@ func manager(runtime command.Runtime, version string, cmd *cobra.Command) (*appl
 }
 
 func upCommand(runtime command.Runtime, version string) *cobra.Command {
-	var options applocal.UpOptions
+	options := applocal.UpOptions{ReadinessTimeout: applocal.DefaultReadinessTimeout}
 	cmd := &cobra.Command{Use: "up", Short: "Start the local Axern stack", Args: command.NoArgs, RunE: func(cmd *cobra.Command, _ []string) error {
+		if options.ReadinessTimeout <= 0 {
+			return command.Usage(fmt.Errorf("--wait-timeout must be positive"))
+		}
 		service, err := manager(runtime, version, cmd)
 		if err != nil {
 			return err
 		}
-		return service.Up(cmd.Context(), options)
+		ctx := cmd.Context()
+		cancel := func() {}
+		if runtime.Options != nil && runtime.Options.Timeout > 0 {
+			ctx, cancel = context.WithTimeout(ctx, runtime.Options.Timeout)
+		}
+		defer cancel()
+		return service.Up(ctx, options)
 	}}
 	cmd.Flags().StringVar(&options.Profile, "profile", "", "profile: default or observability; omitted preserves the current profile")
 	cmd.Flags().BoolVar(&options.Use, "use", false, "select the local context even when another context is active")
+	cmd.Flags().DurationVar(&options.ReadinessTimeout, "wait-timeout", options.ReadinessTimeout, "wait for fresh local capability certification; bounded by --timeout")
 	return cmd
 }
 

--- a/apps/cli/internal/commands/local/command_test.go
+++ b/apps/cli/internal/commands/local/command_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/cofy-x/axern/apps/cli/internal/command"
 	applocal "github.com/cofy-x/axern/apps/cli/internal/localruntime"
@@ -26,6 +27,31 @@ func TestLocalLifecycleSurface(t *testing.T) {
 		if doctor.Flags().Lookup(name) == nil {
 			t.Fatalf("local doctor flag --%s is missing", name)
 		}
+	}
+	up, _, err := cmd.Find([]string{"up"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	waitTimeout := up.Flags().Lookup("wait-timeout")
+	if waitTimeout == nil {
+		t.Fatal("local up flag --wait-timeout is missing")
+	}
+	if waitTimeout.DefValue != applocal.DefaultReadinessTimeout.String() {
+		t.Fatalf("--wait-timeout default = %q, want %q", waitTimeout.DefValue, applocal.DefaultReadinessTimeout)
+	}
+}
+
+func TestLocalUpRejectsNonPositiveReadinessTimeout(t *testing.T) {
+	runtime := command.Runtime{Options: &command.Options{}}
+	cmd := upCommand(runtime, "1.2.3")
+	cmd.SetArgs([]string{"--wait-timeout", "0s"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--wait-timeout must be positive") {
+		t.Fatalf("local up error = %v", err)
+	}
+
+	if applocal.DefaultReadinessTimeout <= 3*time.Minute {
+		t.Fatalf("default readiness timeout = %s, must cover serialized fresh-node certification", applocal.DefaultReadinessTimeout)
 	}
 }
 

--- a/apps/cli/internal/localruntime/manager.go
+++ b/apps/cli/internal/localruntime/manager.go
@@ -35,6 +35,12 @@ type PipelineRunner interface {
 	Pipe(context.Context, io.Writer, io.Writer, string, []string, string, []string) error
 }
 
+// DefaultReadinessTimeout covers fresh-node runtime capability certification.
+// The destructive runtime conformance probes are deliberately serialized, so
+// their first trustworthy snapshot can take longer than an ordinary service
+// health check on an uncached host.
+const DefaultReadinessTimeout = 10 * time.Minute
+
 type ExecRunner struct{}
 
 func (ExecRunner) Run(ctx context.Context, stdout, stderr io.Writer, name string, args ...string) error {
@@ -301,7 +307,11 @@ func (m *Manager) up(ctx context.Context, options UpOptions) error {
 	if err := m.composeRun(ctx, options.Profile, args...); err != nil {
 		return err
 	}
-	if err := m.waitReady(ctx, 3*time.Minute); err != nil {
+	readinessTimeout := options.ReadinessTimeout
+	if readinessTimeout <= 0 {
+		readinessTimeout = DefaultReadinessTimeout
+	}
+	if err := m.waitReady(ctx, readinessTimeout); err != nil {
 		m.printStartupDiagnostics(options.Profile)
 		return err
 	}

--- a/apps/cli/internal/localruntime/types.go
+++ b/apps/cli/internal/localruntime/types.go
@@ -66,8 +66,9 @@ type DoctorOptions struct {
 }
 
 type UpOptions struct {
-	Profile string
-	Use     bool
+	Profile          string
+	Use              bool
+	ReadinessTimeout time.Duration
 }
 
 type LogOptions struct {


### PR DESCRIPTION
## Summary

- replace the hidden fixed three-minute local readiness deadline with an explicit `local up --wait-timeout` budget that defaults to ten minutes
- bound the whole local startup path by the existing global `--timeout` when supplied
- keep waiting for the exact runsc ephemeral-storage hard-limit proof; no admission or writable-rootfs enforcement is weakened
- cover the public flag/default and invalid timeout contract

## Root cause

Fresh nodes serialize destructive runtime conformance probes. Both architectures in immutable v0.6.1 release run 33288501894 reached healthy node/gateway state but were still certifying `PLATFORM_CAPABILITY_RUNSC_EPHEMERAL_STORAGE_HARD_LIMIT` when the unrelated internal three-minute timer fired. The previous local validation had warm state and did not expose that source-free critical path.

v0.6.1 remains an unpublished immutable candidate. This code fix will be released as v0.6.2; no v0.6.1 tag or candidate digest will move.

## Validation

- `go test ./apps/cli/...`
- `go vet ./apps/cli/...`
- `make release-check`
- `make open-source-check`
- `bash scripts/release/sdk-data-plane-contract-check.sh`
- `git diff --check`
- candidate-only branch release workflow will validate fresh linux/amd64 and linux/arm64 source-free startup before merge

Closes #95
Refs #78
Refs #93
