### PR TITLE
fix(local): expose capability certification failures

### DIFF
--- a/apps/cli/internal/localruntime/manager.go
+++ b/apps/cli/internal/localruntime/manager.go
@@ -1102,22 +1102,33 @@ type localNodeReadinessPayload struct {
 				} `json:"runtime_slots"`
 			} `json:"pools"`
 			CapabilitySnapshot struct {
-				Sequence     uint64 `json:"sequence"`
-				Observations []struct {
-					Key struct {
-						Kind struct {
-							Platform capabilityv1.PlatformCapability `json:"Platform"`
-						} `json:"Kind"`
-					} `json:"key"`
-					State      capabilityv1.CapabilityState `json:"state"`
-					ValidUntil *struct {
-						Seconds int64 `json:"seconds"`
-						Nanos   int32 `json:"nanos"`
-					} `json:"valid_until"`
-				} `json:"observations"`
+				Sequence     uint64                       `json:"sequence"`
+				Observations []localCapabilityObservation `json:"observations"`
 			} `json:"capability_snapshot"`
 		} `json:"summary"`
 	} `json:"nodes"`
+}
+
+type localCapabilityObservation struct {
+	Key struct {
+		Kind struct {
+			Platform capabilityv1.PlatformCapability `json:"Platform"`
+		} `json:"Kind"`
+	} `json:"key"`
+	State      capabilityv1.CapabilityState      `json:"state"`
+	Reason     string                            `json:"reason"`
+	ReasonCode capabilityv1.CapabilityReasonCode `json:"reason_code"`
+	ValidUntil *struct {
+		Seconds int64 `json:"seconds"`
+		Nanos   int32 `json:"nanos"`
+	} `json:"valid_until"`
+	Dependencies []struct {
+		Key struct {
+			Kind struct {
+				Platform capabilityv1.PlatformCapability `json:"Platform"`
+			} `json:"Kind"`
+		} `json:"key"`
+	} `json:"dependencies"`
 }
 
 func (m *Manager) nodeReadiness(ctx context.Context, client *http.Client, expectedNodeID string, requiredCapabilities []capabilityv1.PlatformCapability) (bool, string) {
@@ -1160,24 +1171,45 @@ func evaluateLocalNodeReadiness(payload localNodeReadinessPayload, expectedNodeI
 		if node.Summary.CapabilitySnapshot.Sequence == 0 {
 			return false, "local capability snapshot is warming"
 		}
-		available := make(map[capabilityv1.PlatformCapability]bool, len(node.Summary.CapabilitySnapshot.Observations))
+		observations := make(map[capabilityv1.PlatformCapability]localCapabilityObservation, len(node.Summary.CapabilitySnapshot.Observations))
 		for _, observation := range node.Summary.CapabilitySnapshot.Observations {
-			if observation.State != capabilityv1.CapabilityState_CAPABILITY_STATE_AVAILABLE {
-				continue
-			}
-			if observation.ValidUntil != nil && !time.Unix(observation.ValidUntil.Seconds, int64(observation.ValidUntil.Nanos)).After(now) {
-				continue
-			}
-			available[observation.Key.Kind.Platform] = true
+			observations[observation.Key.Kind.Platform] = observation
 		}
 		for _, capability := range requiredCapabilities {
-			if !available[capability] {
-				return false, fmt.Sprintf("required local capability %s is warming or unavailable", capability.String())
+			observation, present := observations[capability]
+			if present && observation.State == capabilityv1.CapabilityState_CAPABILITY_STATE_AVAILABLE {
+				if observation.ValidUntil == nil || time.Unix(observation.ValidUntil.Seconds, int64(observation.ValidUntil.Nanos)).After(now) {
+					continue
+				}
+				return false, fmt.Sprintf("required local capability %s expired", capability.String())
 			}
+			return false, localCapabilityUnavailableReason(capability, observation, present, observations)
 		}
 		return true, ""
 	}
 	return false, fmt.Sprintf("local node %q is not registered", expectedNodeID)
+}
+
+func localCapabilityUnavailableReason(capability capabilityv1.PlatformCapability, observation localCapabilityObservation, present bool, observations map[capabilityv1.PlatformCapability]localCapabilityObservation) string {
+	prefix := fmt.Sprintf("required local capability %s is warming or unavailable", capability.String())
+	if !present {
+		return prefix
+	}
+	reason := strings.TrimSpace(observation.Reason)
+	for _, dependency := range observation.Dependencies {
+		candidate, ok := observations[dependency.Key.Kind.Platform]
+		if !ok || candidate.State == capabilityv1.CapabilityState_CAPABILITY_STATE_AVAILABLE {
+			continue
+		}
+		if dependencyReason := strings.TrimSpace(candidate.Reason); dependencyReason != "" {
+			reason = fmt.Sprintf("dependency %s: %s", dependency.Key.Kind.Platform.String(), dependencyReason)
+			break
+		}
+	}
+	if reason == "" {
+		return prefix
+	}
+	return prefix + ": " + reason
 }
 
 func (m *Manager) lock() (func(), error) {

--- a/apps/cli/internal/localruntime/readiness_test.go
+++ b/apps/cli/internal/localruntime/readiness_test.go
@@ -17,8 +17,33 @@ func TestLocalNodeReadinessPayloadRequiresDefaultWorkloadCapabilities(t *testing
 	}
 
 	payload.Nodes[0].Summary.CapabilitySnapshot.Observations[1].State = capabilityv1.CapabilityState_CAPABILITY_STATE_UNAVAILABLE
-	if ready, reason := evaluateLocalNodeReadiness(payload, LocalNodeID, localDefaultWorkloadCapabilities, time.Now()); ready || reason != "required local capability PLATFORM_CAPABILITY_RUNSC_EPHEMERAL_STORAGE_HARD_LIMIT is warming or unavailable" {
+	payload.Nodes[0].Summary.CapabilitySnapshot.Observations[1].Reason = "quota probe failed"
+	if ready, reason := evaluateLocalNodeReadiness(payload, LocalNodeID, localDefaultWorkloadCapabilities, time.Now()); ready || reason != "required local capability PLATFORM_CAPABILITY_RUNSC_EPHEMERAL_STORAGE_HARD_LIMIT is warming or unavailable: quota probe failed" {
 		t.Fatalf("unavailable capability result = ready:%t reason:%q", ready, reason)
+	}
+}
+
+func TestLocalNodeReadinessReportsUnavailableDependency(t *testing.T) {
+	payload := readyLocalNodePayload(time.Now().Add(time.Minute))
+	derived := &payload.Nodes[0].Summary.CapabilitySnapshot.Observations[1]
+	derived.State = capabilityv1.CapabilityState_CAPABILITY_STATE_UNAVAILABLE
+	derived.Reason = "one or more capability dependencies are unavailable"
+	var dependency struct {
+		Key struct {
+			Kind struct {
+				Platform capabilityv1.PlatformCapability `json:"Platform"`
+			} `json:"Kind"`
+		} `json:"key"`
+	}
+	dependency.Key.Kind.Platform = capabilityv1.PlatformCapability_PLATFORM_CAPABILITY_RUNSC_EPHEMERAL_ENFORCEMENT_SELF_TEST
+	derived.Dependencies = append(derived.Dependencies, dependency)
+	base := localCapabilityObservation{State: capabilityv1.CapabilityState_CAPABILITY_STATE_UNAVAILABLE, Reason: "sandbox exited before quota result"}
+	base.Key.Kind.Platform = dependency.Key.Kind.Platform
+	payload.Nodes[0].Summary.CapabilitySnapshot.Observations = append(payload.Nodes[0].Summary.CapabilitySnapshot.Observations, base)
+
+	ready, reason := evaluateLocalNodeReadiness(payload, LocalNodeID, localDefaultWorkloadCapabilities, time.Now())
+	if ready || reason != "required local capability PLATFORM_CAPABILITY_RUNSC_EPHEMERAL_STORAGE_HARD_LIMIT is warming or unavailable: dependency PLATFORM_CAPABILITY_RUNSC_EPHEMERAL_ENFORCEMENT_SELF_TEST: sandbox exited before quota result" {
+		t.Fatalf("dependency result = ready:%t reason:%q", ready, reason)
 	}
 }
 
@@ -66,7 +91,7 @@ func TestLocalNodeReadinessPayloadDecodesDebugCapabilityKeys(t *testing.T) {
 
 func readyLocalNodePayload(validUntil time.Time) localNodeReadinessPayload {
 	var payload localNodeReadinessPayload
-	payload.Nodes = append(payload.Nodes, struct {
+	payload.Nodes = make([]struct {
 		NodeID       string `json:"node_id"`
 		Fresh        bool   `json:"fresh"`
 		SummaryFresh bool   `json:"summary_fresh"`
@@ -85,23 +110,15 @@ func readyLocalNodePayload(validUntil time.Time) localNodeReadinessPayload {
 				} `json:"runtime_slots"`
 			} `json:"pools"`
 			CapabilitySnapshot struct {
-				Sequence     uint64 `json:"sequence"`
-				Observations []struct {
-					Key struct {
-						Kind struct {
-							Platform capabilityv1.PlatformCapability `json:"Platform"`
-						} `json:"Kind"`
-					} `json:"key"`
-					State      capabilityv1.CapabilityState `json:"state"`
-					ValidUntil *struct {
-						Seconds int64 `json:"seconds"`
-						Nanos   int32 `json:"nanos"`
-					} `json:"valid_until"`
-				} `json:"observations"`
+				Sequence     uint64                       `json:"sequence"`
+				Observations []localCapabilityObservation `json:"observations"`
 			} `json:"capability_snapshot"`
 		} `json:"summary"`
-	}{NodeID: LocalNodeID, Fresh: true, SummaryFresh: true})
+	}, 1)
 	node := &payload.Nodes[0]
+	node.NodeID = LocalNodeID
+	node.Fresh = true
+	node.SummaryFresh = true
 	node.Summary.Components.Axnoded.Ready = true
 	node.Summary.Components.Imagemgr.Reachable = true
 	node.Summary.Pools.RuntimeSlots = &struct {
@@ -109,18 +126,7 @@ func readyLocalNodePayload(validUntil time.Time) localNodeReadinessPayload {
 	}{Capacity: 16}
 	node.Summary.CapabilitySnapshot.Sequence = 1
 	for _, platform := range localDefaultWorkloadCapabilities {
-		var observation struct {
-			Key struct {
-				Kind struct {
-					Platform capabilityv1.PlatformCapability `json:"Platform"`
-				} `json:"Kind"`
-			} `json:"key"`
-			State      capabilityv1.CapabilityState `json:"state"`
-			ValidUntil *struct {
-				Seconds int64 `json:"seconds"`
-				Nanos   int32 `json:"nanos"`
-			} `json:"valid_until"`
-		}
+		var observation localCapabilityObservation
 		observation.Key.Kind.Platform = platform
 		observation.State = capabilityv1.CapabilityState_CAPABILITY_STATE_AVAILABLE
 		observation.ValidUntil = &struct {

--- a/scripts/release/local-release-smoke.sh
+++ b/scripts/release/local-release-smoke.sh
@@ -18,6 +18,17 @@ diagnostics() {
   done
   echo "--- local status ---" >&2
   AXERN_HOME="${smoke_root}" "${cli}" --config "${smoke_root}/config.json" --timeout 30s local status >&2 || true
+  echo "--- local capability snapshot ---" >&2
+  curl --fail --silent --show-error --max-time 10 http://127.0.0.1:24101/nodesz >&2 || true
+  echo >&2
+  node_container="$(docker ps \
+    --filter label=com.docker.compose.project=axern-local \
+    --filter label=com.docker.compose.service=node \
+    --format '{{.ID}}' | head -n 1)"
+  if [[ -n "${node_container}" ]]; then
+    echo "--- axnoded log ---" >&2
+    docker exec "${node_container}" sh -c 'tail -n 500 /var/log/axnoded/axnoded.log' >&2 || true
+  fi
   echo "--- local logs ---" >&2
   AXERN_HOME="${smoke_root}" "${cli}" --config "${smoke_root}/config.json" --timeout 30s local logs --tail 200 >&2 || true
 }


### PR DESCRIPTION
Closes #95

Refs #93

## Summary
- surface the exact unavailable or expired capability reason from `axern local up`
- follow derived capability dependencies to the failing base observation
- capture `/nodesz` and the in-container axnoded log in source-free release diagnostics

## Validation
- `go test ./apps/cli/...`
- `go vet ./apps/cli/...`
- `make axern-cli-check-architecture`
- `make axern-cli-build`
- `make release-check`
- `make open-source-check`
- `bash scripts/release/sdk-data-plane-contract-check.sh`
- `git diff HEAD --check`