### PR TITLE
fix(runtime): decouple OCI startup from DNS

### DIFF
--- a/runtime/axnoded/docs/configuration.md
+++ b/runtime/axnoded/docs/configuration.md
@@ -163,7 +163,12 @@ record cannot be safely rebound to a future allocation.
 ### Runtime DNS
 
 `[plugin.runtime.dns]` controls resolver files materialized into OCI bundles.
-When `nameservers` is empty, axnoded derives usable resolvers from the node.
+When `nameservers` is empty, axnoded derives usable resolvers from the node. If
+the node exposes only loopback resolvers or no usable resolver, axnoded owns an
+inert `/etc/resolv.conf` for the sandbox instead of blocking OCI creation or
+inventing a public fallback. Resolver-independent workloads continue to run;
+DNS diagnostics and domain-policy forwarding remain unavailable until the node
+has a verified upstream resolver.
 
 | Key | Meaning |
 | --- | --- |

--- a/runtime/axnoded/internal/runtime/oci/loader_test.go
+++ b/runtime/axnoded/internal/runtime/oci/loader_test.go
@@ -2,6 +2,7 @@ package oci
 
 import (
 	"encoding/json"
+	"errors"
 	"net"
 	"os"
 	"path/filepath"
@@ -699,12 +700,51 @@ options ndots:0
 	}
 }
 
-func TestBuildResolvConfRejectsMissingUsableNameserver(t *testing.T) {
-	_, err := buildResolvConf(RuntimeDNSConfig{
+func TestBuildResolvConfOwnsInertFileWithoutDerivedNameserver(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "missing-resolv.conf")
+	got, err := buildResolvConf(RuntimeDNSConfig{HostResolvConfPaths: []string{missing}})
+	if err != nil {
+		t.Fatalf("buildResolvConf() error = %v", err)
+	}
+	if got != noNameserverResolvConf {
+		t.Fatalf("buildResolvConf() = %q, want inert resolver file %q", got, noNameserverResolvConf)
+	}
+
+	loader, err := newTestBundleLoader(t, "", t.TempDir(), WithRuntimeDNSConfig(RuntimeDNSConfig{HostResolvConfPaths: []string{missing}}))
+	if err != nil {
+		t.Fatalf("NewBundleLoader() error = %v", err)
+	}
+	bundleDir, generated, err := loader.Generate(LoadOptions{
+		ContainerID: "resolver-independent",
+		Request: &apipb.CreateContainerRequest{
+			Command: []string{"/bin/true"},
+			Rootfs:  &apipb.Rootfs{RootDir: t.TempDir()},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+	resolvPath := filepath.Join(bundleDir, "sandbox-files", "resolv.conf")
+	content, err := os.ReadFile(resolvPath)
+	if err != nil || string(content) != noNameserverResolvConf {
+		t.Fatalf("managed resolv.conf = %q, err=%v", content, err)
+	}
+	assertMountPresent(t, generated.Mounts, "/etc/resolv.conf", resolvPath)
+}
+
+func TestBuildResolvConfRejectsInvalidExplicitNameserver(t *testing.T) {
+	_, err := buildResolvConf(RuntimeDNSConfig{Nameservers: []string{"127.0.0.1", "invalid"}})
+	if !errors.Is(err, errNoUsableNameserver) {
+		t.Fatalf("buildResolvConf() error = %v, want no usable nameserver", err)
+	}
+}
+
+func TestResolveRuntimeDNSNameserversRemainsStrictWithoutDerivedNameserver(t *testing.T) {
+	_, err := ResolveRuntimeDNSNameservers(RuntimeDNSConfig{
 		HostResolvConfPaths: []string{filepath.Join(t.TempDir(), "missing-resolv.conf")},
 	})
-	if err == nil {
-		t.Fatal("buildResolvConf() error = nil, want missing nameserver error")
+	if !errors.Is(err, errNoUsableNameserver) {
+		t.Fatalf("ResolveRuntimeDNSNameservers() error = %v, want no usable nameserver", err)
 	}
 }
 

--- a/runtime/axnoded/internal/runtime/oci/spec_runtime_dns.go
+++ b/runtime/axnoded/internal/runtime/oci/spec_runtime_dns.go
@@ -2,6 +2,7 @@ package oci
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -13,11 +14,22 @@ var (
 	dockerExtServerPattern  = regexp.MustCompile(`\b[a-zA-Z_]+\(([0-9a-fA-F:.]+)\)`)
 	defaultHostResolvPaths  = []string{"/etc/resolv.conf", "/run/systemd/resolve/resolv.conf"}
 	defaultResolvConfOption = []string{"ndots:0"}
+	errNoUsableNameserver   = errors.New("no usable nameserver found")
 )
+
+const noNameserverResolvConf = "# no usable nameserver configured\n"
 
 func buildResolvConf(config RuntimeDNSConfig) (string, error) {
 	nameservers, searchDomains, options, err := resolveRuntimeDNS(config)
 	if err != nil {
+		// An absent node-derived resolver is not an OCI execution dependency.
+		// Own /etc/resolv.conf with an inert file so resolver-independent
+		// sandboxes can still run without inheriting a loopback-only host file.
+		// Resolver-dependent callers use ResolveRuntimeDNSNameservers below and
+		// retain the strict failure contract.
+		if len(config.Nameservers) == 0 && errors.Is(err, errNoUsableNameserver) {
+			return noNameserverResolvConf, nil
+		}
 		return "", err
 	}
 	return buildResolvConfFromParts(nameservers, searchDomains, options)
@@ -36,7 +48,7 @@ func resolveRuntimeDNS(config RuntimeDNSConfig) ([]string, []string, []string, e
 	if len(config.Nameservers) > 0 {
 		nameservers := normalizeNameservers(config.Nameservers)
 		if len(nameservers) == 0 {
-			return nil, nil, nil, fmt.Errorf("derive OCI runtime DNS config: no usable nameserver found")
+			return nil, nil, nil, fmt.Errorf("derive OCI runtime DNS config: %w", errNoUsableNameserver)
 		}
 		return nameservers, append([]string(nil), config.SearchDomains...), append([]string(nil), config.Options...), nil
 	}
@@ -50,7 +62,7 @@ func resolveRuntimeDNS(config RuntimeDNSConfig) ([]string, []string, []string, e
 			return nameservers, searchDomains, options, nil
 		}
 	}
-	return nil, nil, nil, fmt.Errorf("derive OCI runtime DNS config: no usable nameserver found")
+	return nil, nil, nil, fmt.Errorf("derive OCI runtime DNS config: %w", errNoUsableNameserver)
 }
 
 func buildResolvConfFromContent(content string, defaultOptions []string) (string, error) {
@@ -96,7 +108,7 @@ func resolveRuntimeDNSFromContent(content string, defaultOptions []string) ([]st
 	}
 	nameservers = normalizeNameservers(nameservers)
 	if len(nameservers) == 0 {
-		return nil, nil, nil, fmt.Errorf("build OCI runtime resolv.conf: no usable nameserver found")
+		return nil, nil, nil, fmt.Errorf("build OCI runtime resolv.conf: %w", errNoUsableNameserver)
 	}
 	return nameservers, searchDomains, options, nil
 }
@@ -104,7 +116,7 @@ func resolveRuntimeDNSFromContent(content string, defaultOptions []string) ([]st
 func buildResolvConfFromParts(nameservers []string, searchDomains []string, options []string) (string, error) {
 	nameservers = normalizeNameservers(nameservers)
 	if len(nameservers) == 0 {
-		return "", fmt.Errorf("build OCI runtime resolv.conf: no usable nameserver found")
+		return "", fmt.Errorf("build OCI runtime resolv.conf: %w", errNoUsableNameserver)
 	}
 	var builder strings.Builder
 	for _, nameserver := range nameservers {


### PR DESCRIPTION
Closes #98
Refs #93
Refs #78

## Summary

- allow resolver-independent OCI sandboxes to start when the node has no usable upstream resolver
- materialize an owned inert `/etc/resolv.conf` without inventing a public DNS fallback
- keep explicit invalid resolver configuration and DNS-dependent policy resolution fail-closed
- document the resolver-independent runtime contract

## Validation

- `go test ./runtime/axnoded/internal/runtime/oci`
- `make -C runtime/axnoded test-host`
- `go vet ./runtime/axnoded/internal/runtime/oci ./runtime/axnoded/internal/service/...`
- `make -C runtime/axnoded check-architecture`
- `make -C runtime/axnoded verify-docker`
- `make agent-doc-check`
- `make release-check`
- `make open-source-check`
- `git diff HEAD^ --check`