### PR TITLE
feat(dev): add tiered verification planner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,34 @@ permissions:
   contents: read
 
 jobs:
+  change-scope:
+    name: Change Scope
+    runs-on: ubuntu-latest
+    outputs:
+      network_policy_linux: ${{ steps.plan.outputs.network_policy_linux }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          fetch-depth: 0
+
+      - name: Select heavyweight verification
+        id: plan
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if [[ "${EVENT_NAME}" == "push" ]]; then
+            scripts/verification/plan.sh --plan --all-heavy --github-output "${GITHUB_OUTPUT}"
+          else
+            scripts/verification/plan.sh \
+              --base "${BASE_SHA}" \
+              --head "${HEAD_SHA}" \
+              --plan \
+              --github-output "${GITHUB_OUTPUT}"
+          fi
+
   open-source:
     name: Open Source
     runs-on: ubuntu-latest
@@ -57,6 +85,20 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          fetch-depth: 0
+
+      - name: Validate current change scope
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if [[ "${EVENT_NAME}" == "push" ]]; then
+            scripts/verification/plan.sh --plan --all-heavy
+          else
+            scripts/verification/plan.sh --base "${BASE_SHA}" --head "${HEAD_SHA}" --plan
+          fi
 
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
@@ -128,13 +170,19 @@ jobs:
 
   network-policy-linux:
     name: Network Policy Linux
+    needs: change-scope
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
+      - name: Explain skipped matrix
+        if: needs.change-scope.outputs.network_policy_linux != 'true'
+        run: echo "Full network-policy matrix is not affected by this change set."
+
       - name: Run full native Linux network-policy correctness matrix
+        if: needs.change-scope.outputs.network_policy_linux == 'true'
         run: make axnoded-verify-network-policy-linux-matrix
 
   rust:

--- a/.github/workflows/managed-rollout-ci.yml
+++ b/.github/workflows/managed-rollout-ci.yml
@@ -16,6 +16,7 @@ on:
       - "deploy/local/**"
       - "scripts/axrun/**"
       - "scripts/dev-env/**"
+      - "scripts/verification/**"
       - "Makefile"
       - "mk/axrun.mk"
       - "mk/dev-env.mk"
@@ -41,6 +42,7 @@ on:
       - "deploy/local/**"
       - "scripts/axrun/**"
       - "scripts/dev-env/**"
+      - "scripts/verification/**"
       - "Makefile"
       - "mk/axrun.mk"
       - "mk/dev-env.mk"
@@ -69,8 +71,32 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          fetch-depth: 0
+
+      - name: Select heavyweight verification
+        id: scope
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if [[ "${EVENT_NAME}" == "pull_request" ]]; then
+            scripts/verification/plan.sh \
+              --base "${BASE_SHA}" \
+              --head "${HEAD_SHA}" \
+              --plan \
+              --github-output "${GITHUB_OUTPUT}"
+          else
+            scripts/verification/plan.sh --plan --all-heavy --github-output "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Explain skipped gate
+        if: steps.scope.outputs.managed_rollout != 'true'
+        run: echo "Managed rollout behavior is not affected by this change set."
 
       - name: Set up Go
+        if: steps.scope.outputs.managed_rollout == 'true'
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: "1.25.12"
@@ -87,9 +113,11 @@ jobs:
             sdk/go/go.sum
 
       - name: Bootstrap Go dependencies
+        if: steps.scope.outputs.managed_rollout == 'true'
         run: make bootstrap-go
 
       - name: Managed rollout verification
+        if: steps.scope.outputs.managed_rollout == 'true'
         run: make axrun-managed-rollout-compose-e2e
 
       - name: Report runner resources after failure

--- a/.x/coding-standards.md
+++ b/.x/coding-standards.md
@@ -40,13 +40,20 @@ Rules and conventions for Axern contributors and agents.
 ## Validation Baseline
 
 - Prefer root `make` targets when they exist for the scope of the change.
+- Use `make verify-changed-plan` and `make verify-changed` as the normal
+  repository handoff gate. The planner must remain host-safe and fail safe to
+  `make verify-fast-all` for unknown or root-orchestration changes.
 - Changes to repository Markdown should run `make agent-doc-check`.
-- Cross-workspace or root orchestration changes should run `make build`, `make test`, and `make lint`.
+- Cross-workspace or root-orchestration changes use `make verify-fast-all`;
+  add `make build` only when build wiring or produced binaries changed.
 - Go changes should run the relevant package tests, subsystem validation, or the root `make test` for the affected `go.work` member.
 - Rust changes should run `cargo fmt --all --check` and `cargo test --workspace -- --test-threads=1`.
 - TypeScript changes under `sdk/typescript` should run `make sdk-typescript-verify`.
 - Python changes under `sdk/python` should run `make test-py` and `make lint-py`; run `uv build sdk/python` when package metadata or distribution behavior changes.
 - Shared protobuf contract changes should run `make protos`, `make proto-generated-check`, and `make -C sdk/proto lint`. Run generation and generated-output checks before Go compilation, never in parallel with it, because the generator replaces `sdk/go/gen` atomically at the workflow level rather than file by file.
+- Linux, Compose, kind, full-repository, and regional qualification tiers are
+  required only when selected by the owning contract and delivery stage. A
+  smaller smoke never substitutes for a release qualification receipt.
 
 ## Repository Hygiene
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,8 +70,17 @@ updated together.
 
 ## Completing A Change
 
-- Use the narrowest relevant validation from the local contract. Use root
-  `make` targets for cross-workspace changes.
+- Use the narrowest relevant validation from the local contract. After a
+  cohesive edit, run `make verify-changed-plan` and `make verify-changed`; the
+  repository planner is the shared source of truth for host-safe checks and
+  affected heavyweight CI scopes. Use root `make` targets for cross-workspace
+  changes.
+- Do not run Compose, kind, the full repository gate, or regional qualification
+  merely because a normal pull request is approaching merge. Run the affected
+  Linux or local truth path when selected by scope. Reserve `make verify-full`
+  for broad changes and asynchronous post-merge regression, and
+  `make verify-release` plus environment qualification for frozen release
+  candidates.
 - For protobuf changes, run generation and generated-output checks before Go
   compilation; generation replaces `sdk/go/gen` and must not run in parallel
   with compilation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,18 +11,21 @@ Makefile as the stable command surface.
 
 ```bash
 make bootstrap
-make build
-make test
-make lint
-make proto-generated-check
-make agent-doc-check
-make open-source-check
+make verify-changed-plan
+make verify-changed
 ```
 
-Integration-sensitive changes must also run the relevant Compose, kind, or
-runtime smoke documented by the owning module. Pull requests should describe
-the user impact, design tradeoffs, verification performed, and any operational
-risk.
+The change planner runs only host-safe checks and prints whether Linux network
+policy, managed rollout, or release-contract verification is affected. GitHub
+CI is authoritative for selected Linux correctness checks. Integration-sensitive
+changes may also need the narrow Compose, kind, or runtime smoke documented by
+the owning module.
+
+`make verify-full` is reserved for broad changes and asynchronous post-merge
+regression. `make verify-release` is the source and local-deployment release
+gate; regional performance and capacity qualification remain separate frozen-
+candidate workflows. Pull requests should describe the user impact, design
+tradeoffs, verification performed, and any operational risk.
 
 ## Commit Style
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ It builds the current checkout into local `:dev` images and exercises the same p
 make quickstart-source
 ```
 
+For repository development, `make verify-changed` is the normal fast feedback
+entrypoint. Linux correctness, full regression, and release qualification are
+separate tiers; see the [verification tiers](./docs/verification/local-full-verification.md).
+
 ## What You Can Build
 
 - **Agent sandboxes:** execute agent-generated code behind a runsc isolation boundary while retaining process, file, terminal, and output APIs.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -64,6 +64,8 @@ axern local down
 make quickstart-source
 ```
 
+仓库开发通常使用 `make verify-changed` 获得快速反馈。Linux correctness、完整回归和发布资格验证属于不同层级；详见[验证层级](./docs/verification/local-full-verification.md)。
+
 ## 可以构建什么
 
 - **Agent 沙箱：** 在 runsc 隔离边界后执行 agent 生成的代码，同时保留进程、文件、终端和输出 API。

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,9 @@ documents.
 - [Documentation Site Visual Direction](decisions/docs-site-visual-direction.md):
   durable visual, content, interaction, and ownership constraints for the
   public documentation site.
+- [Verification Feedback Tiers](decisions/verification-feedback-tiers.md):
+  separate fast development feedback, Linux correctness, full regression, and
+  frozen-candidate qualification.
 
 ## Product Direction And User Models
 
@@ -75,8 +78,9 @@ material here only when multiple modules need the same model.
 
 ## Verification
 
-- [Local Full Verification](verification/local-full-verification.md): concise
-  repository, Compose, kind, and Nydus verification checklist.
+- [Verification Tiers](verification/local-full-verification.md): change-selected
+  fast checks, Linux correctness, asynchronous full regression, and release
+  qualification boundaries.
 - [Dependency License Policy](legal/dependency-licenses.md): release dependency
   inventory and incompatible-license gate.
 

--- a/docs/decisions/verification-feedback-tiers.md
+++ b/docs/decisions/verification-feedback-tiers.md
@@ -1,0 +1,53 @@
+# Verification Feedback Tiers
+
+## Decision
+
+Axern separates verification into four evidence tiers: change-selected
+host-safe checks, affected Linux or local integration, asynchronous full
+repository regression, and frozen-candidate environment qualification.
+
+Normal pull requests require the host-safe checks selected by the repository
+planner and the corresponding GitHub checks. They do not require a developer to
+run the complete repository, Compose, kind, and regional qualification sequence
+serially before every merge.
+
+The planner is versioned in the repository and is the shared source of truth for
+local recommendations and conditional heavyweight CI work. An unknown or
+planner-owning path fails safe to the complete host-safe gate. Main-branch runs
+retain broad Linux coverage so classification mistakes are detected after
+merge and before release.
+
+Full repository validation is a broad-change or post-merge gate. Environment
+qualification remains bound to one frozen commit, immutable artifact digest,
+environment identity, complete samples, budgets, comparison, and receipt. A
+reduced smoke must use a distinct name and cannot satisfy promotion policy.
+
+## Rationale
+
+Local macOS checks and GitHub Linux checks previously repeated source coverage,
+while multi-hour regional sampling sat on the same foreground critical path.
+This increased feedback time without making each layer more authoritative.
+Assigning one owner to each kind of evidence keeps the normal development loop
+short while preserving stronger release evidence.
+
+The maintainability budgets are five minutes for warm host-safe feedback,
+fifteen minutes for the standard selected PR path, and forty-five minutes for
+asynchronous full regression. Qualification is intentionally outside the PR
+feedback budget.
+
+## Consequences
+
+- A typical edit receives local feedback in minutes rather than after a full
+  deployment regression.
+- Linux-specific behavior remains proven on Linux, not duplicated by macOS.
+- Heavy pull-request checks retain stable names and explicitly succeed without
+  running their workload when the classifier says they are unaffected.
+- Full and qualification failures block release or promotion even when the
+  originating pull request has already merged.
+- The classifier contract must be tested whenever paths or ownership change.
+
+## Revisit When
+
+Revisit the split if classification misses become common, full post-merge
+validation cannot finish before release, or a subsystem's fast gate repeatedly
+exceeds the expected minutes-scale feedback budget.

--- a/docs/verification/local-full-verification.md
+++ b/docs/verification/local-full-verification.md
@@ -1,85 +1,104 @@
 # Verification Tiers
 
-Verification is layered by cost and evidence. A normal local edit must not run
-the deployment qualification matrix or repeatedly execute destructive runtime
-conformance. Run each tier on the same commit and worktree; advance only as far
-as the change and delivery stage require.
+Verification is layered by feedback time and evidence strength. Local feedback,
+Linux correctness, full repository regression, and environment qualification
+have different owners and must not be serialized into every edit-and-merge loop.
+Run each required tier on the same commit and worktree.
 
-## Tier 1: fast contract and unit checks
+| Tier | Expected feedback budget | Merge role |
+| :--- | :--- | :--- |
+| Changed host-safe checks | 5 minutes on a warm workspace | Normal local gate |
+| Selected Linux/local integration | 15 minutes for the standard CI path | Affected PR gate |
+| Full repository regression | 45 minutes | Broad-change or asynchronous post-merge gate |
+| Environment qualification | No PR feedback budget | Frozen-candidate release/promotion gate |
 
-Run targeted package tests while editing, then the host-safe repository subset
-before handoff:
+Treat these as maintainability budgets, not timeouts that weaken correctness.
+When a tier repeatedly exceeds its budget, split its smoke feedback from its
+complete evidence workflow instead of reducing the latter's sample or coverage.
 
-```bash
-go test ./path/to/changed/package ./path/to/adjacent/contract/package
-make -C runtime/axnoded test-host
-make agent-doc-check
-```
+## Tier 1: changed and host-safe checks
 
-When protobufs change, also run the repository proto generation and generated
-checks. Tier 1 must not start real OOM or disk-fill workloads. Its normal budget
-is minutes, not hours.
-
-## Tier 2: affected local Linux integration
-
-Use the Linux devbox or privileged Docker verification only for affected
-runtime boundaries:
+Use the change planner as the normal repository entrypoint. It prints its scope
+before running and never starts Compose, kind, privileged Linux, or environment
+qualification:
 
 ```bash
-make -C runtime/axnoded verify-docker
+make verify-changed-plan
+make verify-changed
 ```
 
-Prefer the narrow runc, runsc, sandboxd, rootfs, cgroup, XFS, or EROFS target
-when the change does not cross both runtimes. A broad runtime/rootfs change may
-also run:
+Set `VERIFY_BASE=<ref>` when the comparison base is not `origin/main`. For a
+broad or unclassifiable source change, the planner fails safe to
+`make verify-fast-all`, the complete host-safe source gate. Protobuf generated
+output checks finish before any Go compilation.
+
+Tier 1 must not start real OOM, disk-fill, or sampled performance workloads. Its
+normal budget is minutes. A normal pull request may merge after its selected
+Tier 1 checks and GitHub checks pass; it does not also require a local full gate.
+
+## Tier 2: affected Linux and local integration
+
+Use the Linux devbox or a narrow privileged Docker verification only for an
+affected runtime boundary:
+
+```bash
+make -C runtime/axnoded verify-docker-runsc
+make -C runtime/axnoded verify-network-policy-linux-smoke
+```
+
+Prefer the narrow runc, runsc, sandboxd, rootfs, cgroup, XFS, EROFS, or network
+policy target when a change does not cross several boundaries. A broad runtime
+or deployment change may also run:
 
 ```bash
 make local-compose-refresh-verify
 make kind-refresh-verify
 ```
 
+The repository change planner emits `network_policy_linux` and
+`managed_rollout` scopes. Pull-request CI uses those outputs to keep stable check
+names while avoiding unrelated heavyweight work. Linux CI is authoritative for
+namespace, cgroup, mount, eBPF, runc, and runsc behavior; macOS is not expected
+to duplicate it.
+
 Compose DNS verification uses a repository-owned authoritative fixture over
-both UDP and TCP. No host resolver or DNS environment variable is used:
+UDP and TCP. The refresh materializes that fixture as the explicit node resolver
+and verifies config, node, and real OCI sandbox DNS paths without host-resolver
+or public-resolver fallback.
+
+Tier 2 proves correctness with a small deterministic matrix. Sampling must not
+turn it into an hours-long qualification. If performance evidence is needed,
+keep the correctness smoke and qualification as distinct profiles and outputs.
+
+## Tier 3: asynchronous full repository gate
+
+`make verify-full` is the broad-change and post-merge repository gate. It is not
+a default prerequisite for every pull-request merge or a command to restart
+after each edit. On failure, first reproduce the named step directly, then use
+the printed `--from <step>` resume point while diagnosing:
 
 ```bash
-make local-compose-refresh-verify
+make verify-full ARGS='--include-local-storage'
+make verify-full ARGS='--include-bpfnet-generate-check'
+make verify-full ARGS='--include-proto-breaking'
 ```
 
-The refresh starts the fixture first, materializes its current container address
-as the explicit axnoded resolver, and then starts the Node. The Node probe reads
-that materialized runtime config and verifies every effective resolver without
-exposing addresses. It never asks egressd to discover DNS and never falls back
-to a public resolver. `local-compose-dns-doctor-smoke` verifies the config,
-Node, and real OCI sandbox DNS layers together with redaction, cleanup, table
-output, and exit-code contracts.
+Use `make verify-release` for the source and local-deployment release gate. It
+includes Axrun and local-storage acceptance, but it does not produce an
+environment qualification receipt.
 
-Tier 2 proves lifecycle and kernel integration with a small deterministic
-matrix. It may exercise a single startup conformance sandbox, but it does not
-run 20-sample environment qualification, maximum-concurrency stages, or the
-complete image-performance matrix. Keep this tier within roughly 30–90 minutes;
-split or narrow a command that approaches multi-hour duration.
+## Tier 4: environment qualification
 
-## Tier 3: full repository gate
+Digest-pinned memory, network-policy performance, capacity, soak, regional
+rollout, and deployed acceptance run only for a frozen release candidate or an
+explicitly scoped investigation. They must execute and collect remotely without
+depending on a live developer shell.
 
-`bash ./scripts/verify-all.sh` remains a release/broad-change gate. It is not a
-command to rerun from the beginning after every edit. On failure use the printed
-`--from <step>` resume point after first reproducing the failing step directly.
-Optional storage, BPF generation, and proto-breaking checks are selected only
-when those surfaces changed:
+A reduced remote smoke may provide correctness feedback, but it must have a
+distinct profile and output and can never be presented as qualification or
+promotion evidence. Full qualification preserves its existing sample counts,
+budgets, immutable artifact identity, environment identity, and receipt checks.
 
-```bash
-bash ./scripts/verify-all.sh --include-local-storage
-bash ./scripts/verify-all.sh --include-bpfnet-generate-check
-bash ./scripts/verify-all.sh --include-proto-breaking
-```
-
-The final `git status --short` must contain only intentional changes and every
-executed tier must record its exact command and result in the handoff.
-
-Destructive environment qualification—real-OOM and quota-fill repetitions,
-page-cache and dirty/writeback attribution, maximum-concurrency stages, system
-reserve calibration, cloud rollout, and deployed acceptance—is intentionally
-outside this repository's local verification contract. Its commands, release
-identity, receipts, and environment policy belong to the deployment workspace
-that owns those environments. Do not duplicate that runbook here or move those
-workloads into `go test`, provider refresh, or per-allocation audit paths.
+The final `git status --short` must contain only intentional changes. The handoff
+records the exact commands and results for the tiers that were required, rather
+than claiming tiers that were skipped by scope.

--- a/mk/root.mk
+++ b/mk/root.mk
@@ -1,6 +1,6 @@
 .PHONY: bootstrap bootstrap-tools \
 		bootstrap-go bootstrap-rust bootstrap-ts bootstrap-py \
-		build test lint fmt clean protos proto-generate proto-generated-check agent-doc-check open-source-check release-check release-build axern-cli-build axern-cli-install axrun-build axrun-install axern-cli-check-architecture axern-cli-dashboard-smoke gatewayd-check-architecture imagemgr-check-architecture axern-cli-e2e axern-cli-image-ref-e2e bpfnetctl-build \
+		build test lint fmt clean protos proto-generate proto-generated-check agent-doc-check open-source-check release-check release-build verification-plan-contract verify-changed verify-changed-plan verify-fast-all verify-full verify-release axern-cli-build axern-cli-install axrun-build axrun-install axern-cli-check-architecture axern-cli-dashboard-smoke gatewayd-check-architecture imagemgr-check-architecture axern-cli-e2e axern-cli-image-ref-e2e bpfnetctl-build \
 		hermetic-dns-contract-check \
 		gateway-dashboard-assets grafana-assets-check \
 		build-go test-go lint-go fmt-go \
@@ -51,6 +51,29 @@ test: test-go test-rust test-ts test-py ## Run all root workspace tests
 
 lint: lint-go lint-rust lint-ts lint-py ## Run non-mutating root workspace checks
 
+verify-changed: ## Run host-safe checks selected from changes against VERIFY_BASE (default: origin/main)
+	bash $(ROOTDIR)/scripts/verification/plan.sh --base "$${VERIFY_BASE:-origin/main}"
+
+verify-changed-plan: ## Print change-selected fast and heavyweight verification scopes
+	bash $(ROOTDIR)/scripts/verification/plan.sh --base "$${VERIFY_BASE:-origin/main}" --plan
+
+verify-fast-all: ## Run the complete host-safe source gate without Compose, kind, or privileged Linux
+	$(MAKE) agent-doc-check
+	$(MAKE) axern-cli-check-architecture gatewayd-check-architecture imagemgr-check-architecture axnoded-check-architecture
+	$(MAKE) -C sdk/proto lint
+	$(MAKE) proto-generated-check
+	$(MAKE) lint
+	$(MAKE) test
+	$(MAKE) -C runtime/axnoded test-host
+	$(MAKE) -C runtime/axnoded vet
+	$(MAKE) -C network/bpfnet test
+
+verify-full: ## Run the serial full repository gate for broad changes or post-merge validation
+	bash $(ROOTDIR)/scripts/verify-all.sh $(ARGS)
+
+verify-release: ## Run the source/deployment release gate; environment qualification remains separate
+	bash $(ROOTDIR)/scripts/verify-all.sh --include-axrun --include-local-storage $(ARGS)
+
 fmt: fmt-go fmt-rust ## Format root Go and Rust workspaces
 
 protos: proto-generate ## Regenerate shared protobuf code and runtime-internal protobufs
@@ -71,6 +94,7 @@ open-source-check: ## Audit the public source tree, credentials, metadata, and d
 	bash $(ROOTDIR)/scripts/open-source-check.sh
 
 release-check: ## Verify release versions and package contracts
+	$(MAKE) verification-plan-contract
 	bash $(ROOTDIR)/scripts/release/version-check.sh
 	bash $(ROOTDIR)/scripts/release/helm-platform-contract-check.sh
 	bash $(ROOTDIR)/scripts/release/homebrew-formula-check.sh
@@ -81,6 +105,9 @@ release-check: ## Verify release versions and package contracts
 	bash $(ROOTDIR)/scripts/release/publication-contract-check.sh
 	bash $(ROOTDIR)/scripts/release/sdk-data-plane-contract-check.sh
 	$(MAKE) helm-lint
+
+verification-plan-contract: ## Verify change classification and heavyweight-gate routing
+	bash $(ROOTDIR)/scripts/verification/plan-test.sh
 
 hermetic-dns-contract-check: ## Verify local verification uses only the repository DNS fixture
 	bash $(ROOTDIR)/scripts/dev-env/hermetic-dns-contract-check.sh

--- a/scripts/verification/plan-test.sh
+++ b/scripts/verification/plan-test.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PLAN="${ROOT_DIR}/scripts/verification/plan.sh"
+work_dir=$(mktemp -d)
+trap 'rm -rf "${work_dir}"' EXIT
+
+assert_plan() {
+  local name=$1 path=$2 expected_fast=$3 expected_network=$4 expected_rollout=$5
+  local paths_file="${work_dir}/${name}.paths" output_file="${work_dir}/${name}.out"
+  printf '%s\n' "${path}" >"${paths_file}"
+  "${PLAN}" --paths-file "${paths_file}" --plan >"${output_file}"
+  grep -Fx "verification.fast=${expected_fast}" "${output_file}" >/dev/null
+  grep -Fx "verification.network_policy_linux=${expected_network}" "${output_file}" >/dev/null
+  grep -Fx "verification.managed_rollout=${expected_rollout}" "${output_file}" >/dev/null
+}
+
+assert_plan docs docs/architecture/runtime-architecture.md docs false false
+assert_plan module-doc apps/axrun/docs/architecture.md docs false false
+assert_plan egress runtime/egressd/internal/enforcement/nft.go egressd true false
+assert_plan axnoded-volume runtime/axnoded/internal/volume/store.go axnoded false false
+assert_plan rollout apps/axrun/internal/application/rollout/execute.go go false true
+assert_plan migration control/controld/internal/postgres/migrations/000005_example.sql go false true
+assert_plan classifier scripts/verification/plan.sh verify-fast-all true true
+assert_plan release-workflow .github/workflows/release.yml verify-fast-all,release-contract true true
+
+github_output="${work_dir}/github.out"
+paths_file="${work_dir}/empty.paths"
+: >"${paths_file}"
+"${PLAN}" --paths-file "${paths_file}" --plan --all-heavy --github-output "${github_output}" >/dev/null
+grep -Fx 'network_policy_linux=true' "${github_output}" >/dev/null
+grep -Fx 'managed_rollout=true' "${github_output}" >/dev/null
+grep -Fx 'release_contract=true' "${github_output}" >/dev/null
+
+printf 'verification_plan_contract_ok=true\n'

--- a/scripts/verification/plan.sh
+++ b/scripts/verification/plan.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+set -Eeo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+base_ref=origin/main
+head_ref=HEAD
+paths_file=""
+github_output=""
+plan_only=false
+all_heavy=false
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/verification/plan.sh [options]
+
+Plan and run the host-safe verification affected by a change set.
+
+Options:
+  --base REF             Compare REF...HEAD (default: origin/main).
+  --head REF             Compare BASE...REF (default: HEAD).
+  --paths-file FILE      Classify newline-delimited repository paths instead of Git diff.
+  --plan                 Print the plan without running commands.
+  --github-output FILE   Append heavyweight scope outputs for GitHub Actions.
+  --all-heavy            Require all heavyweight scopes (main/release validation).
+  -h, --help             Show this help.
+
+The fast plan never starts Compose, kind, privileged Linux, or qualification
+workloads. Heavyweight scopes are consumed by CI; a reduced scope never counts
+as release qualification evidence.
+EOF
+}
+
+while (($# > 0)); do
+  case "$1" in
+    --base) (($# >= 2)) || { echo "--base requires a value" >&2; exit 2; }; base_ref=$2; shift 2 ;;
+    --head) (($# >= 2)) || { echo "--head requires a value" >&2; exit 2; }; head_ref=$2; shift 2 ;;
+    --paths-file) (($# >= 2)) || { echo "--paths-file requires a value" >&2; exit 2; }; paths_file=$2; shift 2 ;;
+    --plan) plan_only=true; shift ;;
+    --github-output) (($# >= 2)) || { echo "--github-output requires a value" >&2; exit 2; }; github_output=$2; shift 2 ;;
+    --all-heavy) all_heavy=true; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown option: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+cd "${ROOT_DIR}"
+paths=()
+if [[ -n "${paths_file}" ]]; then
+  [[ -f "${paths_file}" ]] || { echo "paths file not found: ${paths_file}" >&2; exit 1; }
+  while IFS= read -r path; do [[ -n "${path}" ]] && paths+=("${path}"); done <"${paths_file}"
+else
+  git rev-parse --verify "${base_ref}^{commit}" >/dev/null
+  git rev-parse --verify "${head_ref}^{commit}" >/dev/null
+  while IFS= read -r path; do [[ -n "${path}" ]] && paths+=("${path}"); done < <(
+    {
+      git diff --name-only --diff-filter=ACMR "${base_ref}...${head_ref}"
+      if [[ "${head_ref}" == "HEAD" ]]; then
+        git diff --name-only --diff-filter=ACMR
+        git diff --cached --name-only --diff-filter=ACMR
+        git ls-files --others --exclude-standard
+      fi
+    } | LC_ALL=C sort -u
+  )
+fi
+
+docs=false docs_site=false proto=false root_go=false axnoded=false egressd=false bpfnet=false
+rust=false typescript=false python=false broad=false network_policy_linux=false
+managed_rollout=false release_contract=false
+
+for path in "${paths[@]}"; do
+  case "${path}" in
+    *.md|*.mdx)
+      docs=true
+      case "${path}" in apps/docs/*) docs_site=true ;; esac
+      continue
+      ;;
+  esac
+  case "${path}" in .x/*|docs/*) docs=true ;; esac
+  case "${path}" in apps/docs/*) docs=true; docs_site=true ;; esac
+  case "${path}" in sdk/proto/*|scripts/proto-generate.sh|scripts/proto-generated-check.sh) proto=true; root_go=true; axnoded=true ;; esac
+  case "${path}" in
+    apps/axrun/*|apps/cli/*|control/*|gateway/*|lib/go/*|runtime/imagemgr/*|runtime/tunneld/*|runtime/volumed/*|sdk/go/*|*/go.mod|*/go.sum|go.work|go.work.sum) root_go=true ;;
+  esac
+  case "${path}" in runtime/axnoded/*) axnoded=true ;; esac
+  case "${path}" in runtime/egressd/*) egressd=true ;; esac
+  case "${path}" in network/bpfnet/*) bpfnet=true ;; esac
+  case "${path}" in *.rs|Cargo.toml|Cargo.lock|runtime/imagefsd/*) rust=true ;; esac
+  case "${path}" in *.ts|*.tsx|*.mts|*.cts|sdk/typescript/*|pnpm-workspace.yaml|pnpm-lock.yaml|package.json) typescript=true ;; esac
+  case "${path}" in *.py|sdk/python/*|pyproject.toml|uv.lock) python=true ;; esac
+  case "${path}" in
+    runtime/egressd/*|lib/go/networkpolicy/*|network/bpfnet/*|runtime/axnoded/cmd/network-policy-*|runtime/axnoded/cmd/verify-network-policy-*|runtime/axnoded/internal/egress/*|runtime/axnoded/internal/network/*|runtime/axnoded/internal/bpfnetstatus/*|runtime/axnoded/internal/nodeinventory/bpfnet_*|runtime/axnoded/internal/runtime/oci/spec_network.go|runtime/axnoded/internal/service/egress_*|runtime/axnoded/internal/service/network_policy_*|runtime/axnoded/internal/service/networking/*|runtime/axnoded/internal/service/allocation/egress_*|runtime/axnoded/scripts/qualification/*|sdk/proto/axern/private/runtime/egress/*|sdk/proto/axern/node/sandbox/v1/node.proto) network_policy_linux=true ;;
+  esac
+  case "${path}" in
+    apps/axrun/*|control/controld/*|sdk/proto/axern/private/rollout/*|scripts/axrun/*|scripts/dev-env/compose-managed-rollout-e2e.sh|deploy/local/compose/*managed-rollout*|mk/axrun.mk|.github/workflows/managed-rollout-ci.yml) managed_rollout=true ;;
+  esac
+  case "${path}" in VERSION|.github/workflows/release.yml|scripts/release/*|deploy/helm/*|deploy/images/*|mk/deploy.mk) release_contract=true ;; esac
+  case "${path}" in Makefile|mk/*|scripts/*|.github/*|deploy/*|examples/*) broad=true ;; esac
+  case "${path}" in
+    apps/*|control/*|gateway/*|lib/*|runtime/*|network/*|sdk/*|deploy/*|docs/*|examples/*|scripts/*|mk/*|.github/*|.x/*|AGENTS.md|Makefile|Cargo.toml|Cargo.lock|go.work|go.work.sum|package.json|pnpm-lock.yaml|pnpm-workspace.yaml|pyproject.toml|uv.lock|VERSION) ;;
+    *) broad=true ;;
+  esac
+done
+
+if [[ "${broad}" == "true" ]]; then
+  network_policy_linux=true
+  managed_rollout=true
+fi
+
+if [[ "${all_heavy}" == "true" ]]; then
+  network_policy_linux=true
+  managed_rollout=true
+  release_contract=true
+fi
+
+fast_groups=()
+add_group() {
+  local candidate=$1 existing
+  for existing in "${fast_groups[@]}"; do [[ "${existing}" == "${candidate}" ]] && return; done
+  fast_groups+=("${candidate}")
+}
+
+if [[ "${broad}" == "true" ]]; then
+  add_group verify-fast-all
+  [[ "${release_contract}" == "true" ]] && add_group release-contract
+else
+  [[ "${docs}" == "true" ]] && add_group docs
+  [[ "${docs_site}" == "true" ]] && add_group docs-site
+  [[ "${proto}" == "true" ]] && add_group proto
+  [[ "${root_go}" == "true" ]] && add_group go
+  [[ "${axnoded}" == "true" ]] && add_group axnoded
+  [[ "${egressd}" == "true" ]] && add_group egressd
+  [[ "${bpfnet}" == "true" ]] && add_group bpfnet
+  [[ "${rust}" == "true" ]] && add_group rust
+  [[ "${typescript}" == "true" ]] && add_group typescript
+  [[ "${python}" == "true" ]] && add_group python
+  [[ "${release_contract}" == "true" ]] && add_group release-contract
+fi
+
+printf 'verification.paths=%s\n' "${#paths[@]}"
+if ((${#fast_groups[@]} == 0)); then
+  printf 'verification.fast=none\n'
+else
+  printf 'verification.fast=%s\n' "$(IFS=,; echo "${fast_groups[*]}")"
+fi
+printf 'verification.network_policy_linux=%s\n' "${network_policy_linux}"
+printf 'verification.managed_rollout=%s\n' "${managed_rollout}"
+printf 'verification.release_contract=%s\n' "${release_contract}"
+
+if [[ -n "${github_output}" ]]; then
+  {
+    printf 'network_policy_linux=%s\n' "${network_policy_linux}"
+    printf 'managed_rollout=%s\n' "${managed_rollout}"
+    printf 'release_contract=%s\n' "${release_contract}"
+  } >>"${github_output}"
+fi
+
+if [[ "${plan_only}" == "true" || ${#fast_groups[@]} -eq 0 ]]; then exit 0; fi
+
+run() { printf '+'; printf ' %q' "$@"; printf '\n'; "$@"; }
+for group in "${fast_groups[@]}"; do
+  case "${group}" in
+    verify-fast-all) run make verify-fast-all ;;
+    docs) run make agent-doc-check ;;
+    docs-site) run make docs-check ;;
+    proto) run make -C sdk/proto lint; run make proto-generated-check ;;
+    go) run make test-go; run make lint-go ;;
+    axnoded) run make axnoded-check-architecture; run make -C runtime/axnoded test-host; run make -C runtime/axnoded vet ;;
+    egressd) run make egressd-verify ;;
+    bpfnet) run make -C network/bpfnet test ;;
+    rust) run make test-rust; run make lint-rust ;;
+    typescript) run make test-ts; run make lint-ts ;;
+    python) run make test-py; run make lint-py ;;
+    release-contract) run make release-check ;;
+    *) echo "internal error: unknown verification group ${group}" >&2; exit 1 ;;
+  esac
+done


### PR DESCRIPTION
## Summary

- add a diff-aware `verify-changed` planner with a tested fail-safe fallback
- separate fast host-safe, full regression, and release verification tiers
- keep stable CI check names while conditionally running Network Policy Linux and Managed Rollout workloads
- document the 5/15/45-minute feedback budgets and the qualification boundary

## Validation

- `make verify-changed` (selected `verify-fast-all` for this classifier change)
- `make build`
- `make release-check`
- planner contract tests
- ShellCheck and Actionlint
- agent documentation and Forge wrapper checks

This PR intentionally changes the classifier and CI definitions, so both heavy conditional gates should execute once through the fail-safe path. It does not change HK qualification samples, budgets, digest binding, or receipt contracts.