### PR TITLE
ci: add unattended post-merge regression

### DIFF
--- a/.github/workflows/post-merge-full.yml
+++ b/.github/workflows/post-merge-full.yml
@@ -1,0 +1,157 @@
+name: Post-Merge Full
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: post-merge-full-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  full-regression:
+    name: Full Repository Regression
+    runs-on: ubuntu-24.04
+    timeout-minutes: 180
+    env:
+      GOTOOLCHAIN: local
+      AXERN_DOCKER_CACHE_BACKEND: gha
+      AXERN_NODE_RUNTIME_BASE_CACHE_BACKEND: gha
+      AXERN_GIT_REVISION: ${{ github.sha }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version: "1.25.12"
+          cache-dependency-path: |
+            go.work.sum
+            **/go.sum
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@451ce45ce31d200b52705aadd15ce75018b006de # 1.89.0
+        with:
+          components: rustfmt
+
+      - name: Cache Cargo
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: full-cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            full-cargo-${{ runner.os }}-
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@b0f76dfb45f55f8421693e4803ac7bb65143bd34 # v6
+        with:
+          version: "10.24.0"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: "22.16.0"
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Expose GitHub Actions cache runtime
+        uses: crazy-max/ghaction-github-runtime@04d248b84655b509d8c44dc1d6f990c879747487 # v4.0.0
+
+      - name: Cache verification downloads
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
+        with:
+          path: |
+            runtime/axnoded/.cache/gvisor
+            runtime/axnoded/.cache/minio
+          key: full-verification-downloads-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('runtime/axnoded/scripts/cache/*.sh') }}
+          restore-keys: |
+            full-verification-downloads-${{ runner.os }}-${{ runner.arch }}-
+
+      - name: Install host utilities
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends --yes ripgrep
+
+      - name: Initialize evidence
+        run: |
+          evidence_dir="${RUNNER_TEMP}/post-merge-full"
+          mkdir -p "${evidence_dir}"
+          {
+            printf 'commit=%s\n' "${GITHUB_SHA}"
+            printf 'ref=%s\n' "${GITHUB_REF}"
+            printf 'run_id=%s\n' "${GITHUB_RUN_ID}"
+            printf 'run_attempt=%s\n' "${GITHUB_RUN_ATTEMPT}"
+            printf 'runner_os=%s\n' "${RUNNER_OS}"
+            printf 'runner_arch=%s\n' "${RUNNER_ARCH}"
+          } >"${evidence_dir}/metadata.txt"
+
+      - name: Bootstrap repository dependencies
+        id: bootstrap
+        run: |
+          set -o pipefail
+          make bootstrap 2>&1 | tee "${RUNNER_TEMP}/post-merge-full/bootstrap.log"
+
+      - name: Run full repository regression
+        id: regression
+        run: |
+          set -o pipefail
+          make verify-full 2>&1 | tee "${RUNNER_TEMP}/post-merge-full/verify-full.log"
+
+      - name: Capture failure diagnostics
+        if: failure()
+        run: |
+          evidence_dir="${RUNNER_TEMP}/post-merge-full"
+          {
+            df -h
+            docker system df -v
+            docker ps -a --size --no-trunc
+          } >"${evidence_dir}/diagnostics.txt" 2>&1 || true
+
+      - name: Publish run summary
+        if: always()
+        env:
+          BOOTSTRAP_OUTCOME: ${{ steps.bootstrap.outcome }}
+          REGRESSION_OUTCOME: ${{ steps.regression.outcome }}
+        run: |
+          {
+            echo "## Post-merge full regression"
+            echo
+            echo "- Commit: \`${GITHUB_SHA}\`"
+            echo "- Bootstrap: \`${BOOTSTRAP_OUTCOME}\`"
+            echo "- Regression: \`${REGRESSION_OUTCOME}\`"
+            echo "- Command: \`make verify-full\`"
+          } >>"${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload regression evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: post-merge-full-${{ github.sha }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/post-merge-full
+          if-no-files-found: error
+          retention-days: 14

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,10 @@ updated together.
   for broad changes and asynchronous post-merge regression, and
   `make verify-release` plus environment qualification for frozen release
   candidates.
+- The `Post-Merge Full` workflow owns asynchronous Tier 3 regression for every
+  `main` commit. Do not make it a pull-request check. A newer `main` run may
+  supersede an in-progress ancestor, but release or promotion must wait for a
+  successful `Full Repository Regression` bound to the exact candidate commit.
 - For protobuf changes, run generation and generated-output checks before Go
   compilation; generation replaces `sdk/go/gen` and must not run in parallel
   with compilation.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,9 @@ make quickstart-source
 
 For repository development, `make verify-changed` is the normal fast feedback
 entrypoint. Linux correctness, full regression, and release qualification are
-separate tiers; see the [verification tiers](./docs/verification/local-full-verification.md).
+separate tiers. Every `main` commit receives an unattended, commit-bound full
+regression without delaying pull-request feedback; see the
+[verification tiers](./docs/verification/local-full-verification.md).
 
 ## What You Can Build
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -64,7 +64,7 @@ axern local down
 make quickstart-source
 ```
 
-仓库开发通常使用 `make verify-changed` 获得快速反馈。Linux correctness、完整回归和发布资格验证属于不同层级；详见[验证层级](./docs/verification/local-full-verification.md)。
+仓库开发通常使用 `make verify-changed` 获得快速反馈。Linux correctness、完整回归和发布资格验证属于不同层级；每个 `main` 提交都会获得不延迟 PR 反馈的远端无人值守完整回归。详见[验证层级](./docs/verification/local-full-verification.md)。
 
 ## 可以构建什么
 

--- a/docs/decisions/verification-feedback-tiers.md
+++ b/docs/decisions/verification-feedback-tiers.md
@@ -22,6 +22,13 @@ qualification remains bound to one frozen commit, immutable artifact digest,
 environment identity, complete samples, budgets, comparison, and receipt. A
 reduced smoke must use a distinct name and cannot satisfy promotion policy.
 
+Every `main` commit starts the remote `Post-Merge Full` workflow. It runs the
+repository-owned `make verify-full` entrypoint on a fresh Linux runner and
+retains commit-bound logs and failure diagnostics. A newer `main` commit
+supersedes an in-progress ancestor so the queue converges on the deployable
+state instead of accumulating stale regressions. Manual dispatch reruns the
+same workflow without creating a second verification definition.
+
 ## Rationale
 
 Local macOS checks and GitHub Linux checks previously repeated source coverage,
@@ -44,6 +51,8 @@ feedback budget.
   running their workload when the classifier says they are unaffected.
 - Full and qualification failures block release or promotion even when the
   originating pull request has already merged.
+- Pull requests do not wait for `Post-Merge Full`; release and promotion wait
+  for its successful result on the exact candidate commit.
 - The classifier contract must be tested whenever paths or ownership change.
 
 ## Revisit When

--- a/docs/verification/local-full-verification.md
+++ b/docs/verification/local-full-verification.md
@@ -83,6 +83,23 @@ make verify-full ARGS='--include-bpfnet-generate-check'
 make verify-full ARGS='--include-proto-breaking'
 ```
 
+The `Post-Merge Full` GitHub workflow runs the default `make verify-full` gate
+for every `main` commit and supports manual dispatch. It uses read-only
+repository permissions, language and Docker build caches, a three-hour safety
+timeout, and one concurrency slot per ref. When a newer `main` commit arrives,
+the older in-progress run is cancelled because the newer tree contains and
+supersedes it; a cancelled run is not passing evidence.
+
+Each run publishes a summary plus a 14-day artifact containing the exact
+commit, run identity, bootstrap log, full regression log, and failure
+diagnostics when applicable. GitHub's job log remains the authoritative live
+view. Rerunning the remote job starts from a clean runner; `--from` remains a
+same-workspace local diagnosis aid and is not exposed as a misleading remote
+resume control.
+
+Do not release or promote a commit until its exact `Full Repository Regression`
+job succeeds. The workflow is deliberately not a required pull-request check.
+
 Use `make verify-release` for the source and local-deployment release gate. It
 includes Axrun and local-storage acceptance, but it does not produce an
 environment qualification receipt.

--- a/mk/root.mk
+++ b/mk/root.mk
@@ -1,6 +1,6 @@
 .PHONY: bootstrap bootstrap-tools \
 		bootstrap-go bootstrap-rust bootstrap-ts bootstrap-py \
-		build test lint fmt clean protos proto-generate proto-generated-check agent-doc-check open-source-check release-check release-build verification-plan-contract verify-changed verify-changed-plan verify-fast-all verify-full verify-release axern-cli-build axern-cli-install axrun-build axrun-install axern-cli-check-architecture axern-cli-dashboard-smoke gatewayd-check-architecture imagemgr-check-architecture axern-cli-e2e axern-cli-image-ref-e2e bpfnetctl-build \
+		build test lint fmt clean protos proto-generate proto-generated-check agent-doc-check open-source-check release-check release-build verification-plan-contract post-merge-workflow-contract verify-changed verify-changed-plan verify-fast-all verify-full verify-release axern-cli-build axern-cli-install axrun-build axrun-install axern-cli-check-architecture axern-cli-dashboard-smoke gatewayd-check-architecture imagemgr-check-architecture axern-cli-e2e axern-cli-image-ref-e2e bpfnetctl-build \
 		hermetic-dns-contract-check \
 		gateway-dashboard-assets grafana-assets-check \
 		build-go test-go lint-go fmt-go \
@@ -108,6 +108,10 @@ release-check: ## Verify release versions and package contracts
 
 verification-plan-contract: ## Verify change classification and heavyweight-gate routing
 	bash $(ROOTDIR)/scripts/verification/plan-test.sh
+	$(MAKE) post-merge-workflow-contract
+
+post-merge-workflow-contract: ## Verify unattended post-merge regression workflow invariants
+	bash $(ROOTDIR)/scripts/verification/post-merge-workflow-contract-test.sh
 
 hermetic-dns-contract-check: ## Verify local verification uses only the repository DNS fixture
 	bash $(ROOTDIR)/scripts/dev-env/hermetic-dns-contract-check.sh

--- a/scripts/verification/plan-test.sh
+++ b/scripts/verification/plan-test.sh
@@ -24,6 +24,7 @@ assert_plan rollout apps/axrun/internal/application/rollout/execute.go go false 
 assert_plan migration control/controld/internal/postgres/migrations/000005_example.sql go false true
 assert_plan classifier scripts/verification/plan.sh verify-fast-all true true
 assert_plan release-workflow .github/workflows/release.yml verify-fast-all,release-contract true true
+assert_plan post-merge-workflow .github/workflows/post-merge-full.yml verify-fast-all true true
 
 github_output="${work_dir}/github.out"
 paths_file="${work_dir}/empty.paths"

--- a/scripts/verification/post-merge-workflow-contract-test.sh
+++ b/scripts/verification/post-merge-workflow-contract-test.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORKFLOW="${ROOT_DIR}/.github/workflows/post-merge-full.yml"
+
+required=(
+  "name: Post-Merge Full"
+  "workflow_dispatch:"
+  "push:"
+  "- main"
+  "contents: read"
+  "group: post-merge-full-\${{ github.ref }}"
+  "cancel-in-progress: true"
+  "name: Full Repository Regression"
+  "runs-on: ubuntu-24.04"
+  "timeout-minutes: 180"
+  "AXERN_DOCKER_CACHE_BACKEND: gha"
+  "AXERN_NODE_RUNTIME_BASE_CACHE_BACKEND: gha"
+  "make verify-full"
+  "if: failure()"
+  "if: always()"
+  "retention-days: 14"
+)
+
+for expected in "${required[@]}"; do
+  if ! grep -Fq -- "${expected}" "${WORKFLOW}"; then
+    printf 'post-merge workflow is missing required contract: %s\n' "${expected}" >&2
+    exit 1
+  fi
+done
+
+if grep -Eq '^[[:space:]]+pull_request:' "${WORKFLOW}"; then
+  echo "post-merge full regression must not run as a pull-request gate" >&2
+  exit 1
+fi
+
+if grep -Eq '^[[:space:]]+(checks|contents|packages|pull-requests): write' "${WORKFLOW}"; then
+  echo "post-merge full regression must retain read-only repository permissions" >&2
+  exit 1
+fi
+
+printf 'post_merge_workflow_contract_ok=true\n'


### PR DESCRIPTION
## Summary

- run `make verify-full` remotely for every `main` commit and on manual dispatch
- keep the workflow outside the pull-request critical path while binding evidence to the exact commit
- add read-only permissions, latest-main concurrency, language and Docker caches, a three-hour safety timeout, failure diagnostics, and 14-day artifacts
- add executable workflow invariants and document the Tier 3 ownership contract

## Validation

- `make verify-changed-plan`
- `make verify-changed`
- `make release-check`
- `make post-merge-workflow-contract`
- `make verification-plan-contract`
- ShellCheck
- Actionlint over every workflow
- `make agent-doc-check`

## Rollout

This PR deliberately does not run the full regression as a PR gate. After merge, the first `main` run is the canary for GitHub-hosted runner capacity and all runtime truth paths. Release/promotion enforcement should be wired to the exact successful job only after that canary proves the workflow contract, avoiding an untested release deadlock.