### PR TITLE
ci: install protobuf compiler for full regression

### DIFF
--- a/.github/workflows/post-merge-full.yml
+++ b/.github/workflows/post-merge-full.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Install host utilities
         run: |
           sudo apt-get update
-          sudo apt-get install --no-install-recommends --yes ripgrep
+          sudo apt-get install --no-install-recommends --yes protobuf-compiler ripgrep
 
       - name: Initialize evidence
         run: |

--- a/scripts/verification/post-merge-workflow-contract-test.sh
+++ b/scripts/verification/post-merge-workflow-contract-test.sh
@@ -17,6 +17,7 @@ required=(
   "timeout-minutes: 180"
   "AXERN_DOCKER_CACHE_BACKEND: gha"
   "AXERN_NODE_RUNTIME_BASE_CACHE_BACKEND: gha"
+  "protobuf-compiler ripgrep"
   "make verify-full"
   "if: failure()"
   "if: always()"


### PR DESCRIPTION
## Summary

- install the system `protoc` required by `proto-generated-check` in the unattended post-merge runner
- protect the dependency with the post-merge workflow contract test

## Root cause

The first main-branch canary (run 34567127277) reached `make verify-full` but failed at step 9/33 because `/usr/bin/protoc` was absent. Bootstrap, language toolchains, and the preceding checks succeeded.

## Validation

- `make verify-changed`
- `actionlint .github/workflows/post-merge-full.yml`
- `bash scripts/verification/post-merge-workflow-contract-test.sh`
- `git diff --check`

After merge, the push-to-main canary will rerun `make verify-full` against the merge commit.