### PR TITLE
fix(ci): install protobuf include files for full regression

### DIFF
--- a/.github/workflows/post-merge-full.yml
+++ b/.github/workflows/post-merge-full.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Install host utilities
         run: |
           sudo apt-get update
-          sudo apt-get install --no-install-recommends --yes protobuf-compiler ripgrep
+          sudo apt-get install --no-install-recommends --yes libprotobuf-dev protobuf-compiler ripgrep
 
       - name: Initialize evidence
         run: |

--- a/scripts/verification/post-merge-workflow-contract-test.sh
+++ b/scripts/verification/post-merge-workflow-contract-test.sh
@@ -17,7 +17,7 @@ required=(
   "timeout-minutes: 180"
   "AXERN_DOCKER_CACHE_BACKEND: gha"
   "AXERN_NODE_RUNTIME_BASE_CACHE_BACKEND: gha"
-  "protobuf-compiler ripgrep"
+  "libprotobuf-dev protobuf-compiler ripgrep"
   "make verify-full"
   "if: failure()"
   "if: always()"


### PR DESCRIPTION
## Summary

- install `libprotobuf-dev` alongside `protobuf-compiler` on the Ubuntu full-regression runner
- lock the dependency into the post-merge workflow contract test

## Why

The second post-merge canary reached `proto-generated-check` with `protoc` installed, but failed because `google/protobuf/timestamp.proto` was absent. Ubuntu packages the Well-Known Type headers separately from the compiler executable.

## Validation

- `bash scripts/verification/post-merge-workflow-contract-test.sh`
- `actionlint .github/workflows/*.yml`
- `make verify-changed`
- `git diff --check`

After merge, the push-to-main `Post-Merge Full` workflow will rerun against the exact squash commit.