### PR TITLE
fix(ci): route heavyweight apt downloads through mirror

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,8 @@ jobs:
     needs: change-scope
     runs-on: ubuntu-latest
     timeout-minutes: 90
+    env:
+      APT_MIRROR_SOURCE: "ustc"
     steps:
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6

--- a/.github/workflows/managed-rollout-ci.yml
+++ b/.github/workflows/managed-rollout-ci.yml
@@ -66,6 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 40
     env:
+      APT_MIRROR_SOURCE: "ustc"
       AXERN_MANAGED_ROLLOUT_PRUNE_BUILD_CACHE: "1"
       GOTOOLCHAIN: local
     steps:

--- a/.github/workflows/post-merge-full.yml
+++ b/.github/workflows/post-merge-full.yml
@@ -19,6 +19,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 180
     env:
+      APT_MIRROR_SOURCE: "ustc"
       GOTOOLCHAIN: local
       AXERN_DOCKER_CACHE_BACKEND: gha
       AXERN_NODE_RUNTIME_BASE_CACHE_BACKEND: gha

--- a/scripts/dev-env/build-images.sh
+++ b/scripts/dev-env/build-images.sh
@@ -87,9 +87,9 @@ if [ "${build_runtime_core}" = "true" ]; then
   push_image_after_build "${SERVER_BASE_RUNTIME_IMAGE}"
   IMAGE_REF="${CODING_BASE_RUNTIME_IMAGE}" SERVER_BASE_RUNTIME_IMAGE="${SERVER_BASE_RUNTIME_IMAGE}" APT_MIRROR_SOURCE="${APT_MIRROR_SOURCE}" bash "${AXERN_DEV_ENV_ROOT}/runtime/axnoded/scripts/runtime/build-coding-base-runtime-image.sh" >/dev/null
   push_image_after_build "${CODING_BASE_RUNTIME_IMAGE}"
-  IMAGE_REF="${CODEX_BUNDLE_IMAGE}" bash "${AXERN_DEV_ENV_ROOT}/runtime/axnoded/scripts/runtime/build-codex-bundle-image.sh"
+  IMAGE_REF="${CODEX_BUNDLE_IMAGE}" APT_MIRROR_SOURCE="${APT_MIRROR_SOURCE}" bash "${AXERN_DEV_ENV_ROOT}/runtime/axnoded/scripts/runtime/build-codex-bundle-image.sh"
   push_image_after_build "${CODEX_BUNDLE_IMAGE}"
-  IMAGE_REF="${CLAUDE_CODE_BUNDLE_IMAGE}" bash "${AXERN_DEV_ENV_ROOT}/runtime/axnoded/scripts/runtime/build-claude-code-bundle-image.sh"
+  IMAGE_REF="${CLAUDE_CODE_BUNDLE_IMAGE}" APT_MIRROR_SOURCE="${APT_MIRROR_SOURCE}" bash "${AXERN_DEV_ENV_ROOT}/runtime/axnoded/scripts/runtime/build-claude-code-bundle-image.sh"
   push_image_after_build "${CLAUDE_CODE_BUNDLE_IMAGE}"
   report_image_build_phase "runtime-core" "${phase_started_at}"
 fi

--- a/scripts/release/image-build-contract-check.sh
+++ b/scripts/release/image-build-contract-check.sh
@@ -40,6 +40,19 @@ if missing:
 if not positions["build"] < positions["push"] < positions["consume"]:
     raise SystemExit("node runtime base must be built and pushed before node-all-in-one consumes it")
 
+for image in ("CODEX_BUNDLE_IMAGE", "CLAUDE_CODE_BUNDLE_IMAGE"):
+    contract = f'IMAGE_REF="${{{image}}}" APT_MIRROR_SOURCE="${{APT_MIRROR_SOURCE}}"'
+    if contract not in source:
+        raise SystemExit(f"local image build does not propagate APT_MIRROR_SOURCE to {image}")
+
+for workflow_path in (
+    root / ".github/workflows/ci.yml",
+    root / ".github/workflows/managed-rollout-ci.yml",
+    root / ".github/workflows/post-merge-full.yml",
+):
+    if 'APT_MIRROR_SOURCE: "ustc"' not in workflow_path.read_text():
+        raise SystemExit(f"heavyweight GitHub verification does not select the CI APT mirror: {workflow_path}")
+
 runtime_source = (root / "runtime/axnoded/scripts/lib/verify-docker-common.sh").read_text()
 function_start = runtime_source.index("build_node_runtime_base_image()")
 function_end = runtime_source.index("\n}\n", function_start)


### PR DESCRIPTION
## Summary

- select the existing USTC Ubuntu mirror for GitHub-hosted heavyweight verification
- propagate APT_MIRROR_SOURCE into Codex and Claude Code bundle builds
- enforce the workflow and propagation contracts in the image build check

## Motivation

The same pull request validation hit repeated archive.ubuntu.com:80 connection failures in Managed Rollout and Network Policy image builds. The failures occurred before product verification and persisted across reruns. This keeps production defaults unchanged while making GitHub verification use an explicit supported mirror.

## Validation

- actionlint for all changed workflows
- bash syntax checks
- scripts/release/image-build-contract-check.sh
- make verify-changed-plan
- make verify-changed
- git diff --check

Signed-off-by: wayne <rcywjo@gmail.com>