### PR TITLE
test(axnoded): isolate host resource tests

### DIFF
--- a/runtime/axnoded/internal/container/manager_test.go
+++ b/runtime/axnoded/internal/container/manager_test.go
@@ -9,18 +9,15 @@ import (
 	"context"
 	"errors"
 	"path/filepath"
-	"runtime"
 	"sync"
 	"testing"
 	"time"
 
-	"github.com/cofy-x/axern/runtime/axnoded/config"
 	apipb "github.com/cofy-x/axern/runtime/axnoded/internal/apipb/v1"
 	runtimeapi "github.com/cofy-x/axern/runtime/axnoded/internal/apipb/v1"
 	resourcemanager "github.com/cofy-x/axern/runtime/axnoded/internal/resources"
 	"github.com/cofy-x/axern/runtime/axnoded/internal/runtime/contract"
 	"github.com/cofy-x/axern/runtime/axnoded/internal/runtime/runtimetest"
-	"github.com/cofy-x/axern/runtime/axnoded/internal/storetest"
 	"github.com/cofy-x/axern/runtime/axnoded/pkg/truncindex"
 	commonv1 "github.com/cofy-x/axern/sdk/go/gen/axern/control/common/v1"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
@@ -98,32 +95,17 @@ func (m *stopTestResourceManager) ResourceName() resourcemanager.ResourceName {
 	return resourcemanager.ResourceName("test")
 }
 
-func TestNewManager(t *testing.T) {
+func TestNewManagerRegistersResourceManagers(t *testing.T) {
 	handlers := cmap.New[contract.RuntimeHandler]()
 	healthChan := make(chan bool)
-	manager, err := resourcemanager.NewResourceManager(storetest.NewMockStore(), config.Config{
-		PluginConfig: config.PluginConfig{
-			ResourceConfig: config.ResourceConfig{
-				MaxInstanceNum:     10,
-				CgroupRootName:     "huse",
-				CgroupCacheSize:    8,
-				InterfaceCacheSize: 0,
-			},
-		},
-	})
-	if err != nil && runtime.GOOS != "linux" {
-		t.Skipf("resource manager is not host-safe on %s: %v", runtime.GOOS, err)
-	}
-	assert.NotNil(t, manager)
-	assert.Nil(t, err)
+	resourceManager := &stopTestResourceManager{}
 
-	mgr, err := NewManager("/tmp/mock", handlers, healthChan, manager...)
-	assert.NotNil(t, mgr)
-	assert.Nil(t, err)
-
-	go mgr.Start()
-
-	assert.Nil(t, mgr.loadContainers())
+	mgr, err := NewManager(t.TempDir(), handlers, healthChan, resourceManager)
+	require.NoError(t, err)
+	require.NotNil(t, mgr)
+	registered, ok := mgr.resourceManagers.Get(string(resourceManager.ResourceName()))
+	require.True(t, ok)
+	assert.Same(t, resourceManager, registered)
 }
 
 func TestStoreMetadata(t *testing.T) {

--- a/runtime/axnoded/internal/hostlinux/filestore_linux_test.go
+++ b/runtime/axnoded/internal/hostlinux/filestore_linux_test.go
@@ -28,7 +28,8 @@ func TestDirectoryIdentityRejectsSymlinkAndChangesAfterReplacement(t *testing.T)
 	if _, err := DirectoryIdentity(link); err == nil {
 		t.Fatal("symlink was accepted as durable backing directory identity")
 	}
-	if err := os.Remove(directory); err != nil {
+	retired := filepath.Join(parent, "runsc-retired")
+	if err := os.Rename(directory, retired); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.Mkdir(directory, 0o755); err != nil {

--- a/runtime/axnoded/internal/resources/interface_test.go
+++ b/runtime/axnoded/internal/resources/interface_test.go
@@ -8,7 +8,6 @@ package resources
 import (
 	"errors"
 	"net"
-	"runtime"
 	"testing"
 
 	"github.com/cofy-x/axern/runtime/axnoded/pkg/queue"
@@ -70,12 +69,9 @@ func TestCalcluteCacheSizeOnCPUProbeError(t *testing.T) {
 	assert.Equal(t, rawCacheSize, cacheSize)
 }
 
-func TestDestroyDevice(t *testing.T) {
-	if runtime.GOOS != "linux" {
-		t.Skip("destroyDevice requires Linux netlink")
-	}
+func TestDestroyDeviceRejectsUnrecognizedInterface(t *testing.T) {
 	m := initInterfaceCache()
 
 	err := m.destroyDevice(m.allInterfaces[0])
-	assert.Nil(t, err)
+	assert.ErrorContains(t, err, "cannot reconstruct address")
 }

--- a/runtime/axnoded/internal/resources/manager.go
+++ b/runtime/axnoded/internal/resources/manager.go
@@ -75,6 +75,15 @@ type resizable interface {
 
 // NewResourceManager will init all resource manager and start to sync resource.
 func NewResourceManager(db stateStore, cfg config.Config) ([]Manager, error) {
+	return newResourceManager(db, cfg, LoadNetworkManager, func(db stateStore, cfg config.ResourceConfig, required bool) (resizable, error) {
+		return NewCgroupManager(db, cfg, required)
+	})
+}
+
+type networkManagerFactory func(stateStore, int, int, config.NetworkConfig) (Manager, error)
+type cgroupManagerFactory func(stateStore, config.ResourceConfig, bool) (resizable, error)
+
+func newResourceManager(db stateStore, cfg config.Config, loadNetwork networkManagerFactory, newCgroup cgroupManagerFactory) ([]Manager, error) {
 	managers := make([]Manager, 0)
 	var resizables []resizable
 	cleanup := func(initErr error) error {
@@ -96,7 +105,7 @@ func NewResourceManager(db stateStore, cfg config.Config) ([]Manager, error) {
 	}
 
 	if cfg.InterfaceCacheSize > 0 {
-		interfaceManager, err := LoadNetworkManager(db, cfg.MaxInstanceNum, cfg.InterfaceCacheSize, cfg.PluginConfig.NetworkConfig)
+		interfaceManager, err := loadNetwork(db, cfg.MaxInstanceNum, cfg.InterfaceCacheSize, cfg.PluginConfig.NetworkConfig)
 		if err != nil {
 			return nil, err
 		}
@@ -111,7 +120,7 @@ func NewResourceManager(db stateStore, cfg config.Config) ([]Manager, error) {
 	// A required node always owns a cgroup manager; cache_size=0 merely asks it
 	// to create each one-use allocation cgroup synchronously.
 	if cgroupMode == config.CgroupEnforcementRequired {
-		cgroupManager, err := NewCgroupManager(db, cfg.ResourceConfig, cgroupMode == config.CgroupEnforcementRequired)
+		cgroupManager, err := newCgroup(db, cfg.ResourceConfig, cgroupMode == config.CgroupEnforcementRequired)
 		if err != nil {
 			return nil, cleanup(err)
 		}

--- a/runtime/axnoded/internal/resources/pool_controller_test.go
+++ b/runtime/axnoded/internal/resources/pool_controller_test.go
@@ -6,9 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cofy-x/axern/runtime/axnoded/config"
-	"github.com/cofy-x/axern/runtime/axnoded/internal/storetest"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_runManager(t *testing.T) {
@@ -17,22 +16,10 @@ func Test_runManager(t *testing.T) {
 		maxCacheSize: 18,
 	}
 	runManager(time.Second, rsm)
+	t.Cleanup(func() { require.NoError(t, rsm.ShutDown()) })
 	time.Sleep(time.Second * 3)
 
 	assert.Equal(t, 18, rsm.resourceCount)
-
-	manager, err := NewResourceManager(storetest.NewMockStore(), config.Config{
-		PluginConfig: config.PluginConfig{
-			ResourceConfig: config.ResourceConfig{
-				MaxInstanceNum:     10,
-				CgroupRootName:     "sandbox",
-				CgroupCacheSize:    8,
-				InterfaceCacheSize: 0,
-			},
-		},
-	})
-	assert.NoError(t, err)
-	assert.Equal(t, 1, len(manager))
 }
 
 func Test_runManagerCal(t *testing.T) {
@@ -41,6 +28,7 @@ func Test_runManagerCal(t *testing.T) {
 		maxCacheSize: 5,
 	}
 	runManager(time.Millisecond, rsm)
+	t.Cleanup(func() { require.NoError(t, rsm.ShutDown()) })
 	time.Sleep(time.Millisecond * 500)
 	reconcilePool(rsm)
 	assert.Equal(t, 5, rsm.resourceCount)

--- a/runtime/axnoded/internal/resources/resource_manager_test.go
+++ b/runtime/axnoded/internal/resources/resource_manager_test.go
@@ -3,19 +3,21 @@
 package resources
 
 import (
+	"errors"
 	"testing"
 
 	sdkobs "github.com/cofy-x/axern/lib/go/observability"
 	"github.com/cofy-x/axern/runtime/axnoded/config"
 	"github.com/cofy-x/axern/runtime/axnoded/internal/observability/metrics"
 	"github.com/cofy-x/axern/runtime/axnoded/internal/storetest"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestNewManager(t *testing.T) {
+func TestNewResourceManagerComposesCgroupPoolWithoutHostCgroupAccess(t *testing.T) {
 	metrics.ResetForTest()
+	cgroup := &MockResourceManager{maxSize: 10, maxCacheSize: 8, name: string(CgroupResourceName)}
 
-	manager, err := NewResourceManager(storetest.NewMockStore(), config.Config{
+	managers, err := newResourceManager(storetest.NewMockStore(), config.Config{
 		PluginConfig: config.PluginConfig{
 			ResourceConfig: config.ResourceConfig{
 				MaxInstanceNum:  10,
@@ -25,13 +27,17 @@ func TestNewManager(t *testing.T) {
 				InterfaceCacheSize: 0,
 			},
 		},
+	}, func(stateStore, int, int, config.NetworkConfig) (Manager, error) {
+		return nil, errors.New("network factory should not be called")
+	}, func(stateStore, config.ResourceConfig, bool) (resizable, error) {
+		return cgroup, nil
 	})
-	assert.Nil(t, err)
-	assert.NotNil(t, manager)
+	require.NoError(t, err)
+	require.Len(t, managers, 1)
+	require.Same(t, cgroup, managers[0])
+	t.Cleanup(func() { require.NoError(t, cgroup.ShutDown()) })
 
-	assert.Equal(t, float64(8), metrics.GaugeValueForTest(metrics.MetricSandboxResourceCurrent, map[string]string{
+	require.Equal(t, float64(8), metrics.GaugeValueForTest(metrics.MetricSandboxResourceCurrent, map[string]string{
 		sdkobs.AttrResource: "cgroup",
 	}))
-	// TODO: test interface
-	// assert.Equal(t, float64(1), metrics.GaugeValueForTest(metrics.MetricSandboxResourceCurrent, map[string]string{sdkobs.AttrResource: "interface"}))
 }

--- a/runtime/axnoded/internal/resources/resource_test_support_test.go
+++ b/runtime/axnoded/internal/resources/resource_test_support_test.go
@@ -8,11 +8,12 @@ import (
 
 type MockResourceManager struct {
 	sync.Mutex
-	resourceCount int
-	usingCount    int
-	maxSize       int
-	maxCacheSize  int
-	name          string
+	poolController *poolController
+	resourceCount  int
+	usingCount     int
+	maxSize        int
+	maxCacheSize   int
+	name           string
 }
 
 func (m *MockResourceManager) MaxSizeLimit() int {
@@ -100,7 +101,14 @@ func (m *MockResourceManager) Status() ([]string, []string) {
 }
 
 func (m *MockResourceManager) ShutDown() error {
+	if m.poolController != nil {
+		m.poolController.shutdown()
+	}
 	return nil
+}
+
+func (m *MockResourceManager) setPoolController(controller *poolController) {
+	m.poolController = controller
 }
 
 var (

--- a/runtime/axnoded/internal/runtime/rootfsview/overlay_linux.go
+++ b/runtime/axnoded/internal/runtime/rootfsview/overlay_linux.go
@@ -98,11 +98,22 @@ func unmountOverlayView(rootfs overlayView) error {
 	if rootfs.MergedDir == "" {
 		return nil
 	}
-	if err := unix.Unmount(rootfs.MergedDir, 0); err != nil {
+	mergedDir := filepath.Clean(rootfs.MergedDir)
+	mountInfo, err := mountInfoForPath(mergedDir)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("inspect writable rootfs view before unmount %s: %w", mergedDir, err)
+	}
+	if mountInfo.mountpoint != mergedDir {
+		return nil
+	}
+	if err := unix.Unmount(mergedDir, 0); err != nil {
 		if errors.Is(err, unix.EINVAL) || errors.Is(err, unix.ENOENT) {
 			return nil
 		}
-		return fmt.Errorf("unmount writable rootfs view %s: %w", rootfs.MergedDir, err)
+		return fmt.Errorf("unmount writable rootfs view %s: %w", mergedDir, err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- isolate container and resource-manager composition tests from the host cgroup hierarchy
- make interface and directory-identity tests deterministic on unprivileged Linux filesystems
- skip unmount for rootfs cleanup paths that are not exact mount points
- shut down test pool controllers instead of leaking background workers

## Validation
- `go test ./internal/container ./internal/resources ./internal/hostlinux ./internal/runtime/rootfsview`
- `make -C runtime/axnoded fmt`
- `make -C runtime/axnoded vet`
- `make -C runtime/axnoded test-host`
- `make verify-changed-plan`
- `make verify-changed`
- Linux amd64 test binaries compile for resources, hostlinux, and rootfsview