### PR TITLE
fix(ci): build verify image from local parent

### DIFF
--- a/runtime/axnoded/scripts/lib/verify-docker-common.sh
+++ b/runtime/axnoded/scripts/lib/verify-docker-common.sh
@@ -630,6 +630,14 @@ build_verify_image() {
     build_args=(--pull "${build_args[@]}")
   fi
 
+  if [ "${VERIFY_DOCKER_VARIANT}" = "full" ]; then
+    axern_docker_build_from_local_parent \
+      "${NODE_RUNTIME_BASE_IMAGE_TAG}" \
+      "${build_args[@]}" \
+      "${REPO_ROOT}"
+    return $?
+  fi
+
   if [ -n "${VERIFY_DOCKER_PLATFORM}" ] && docker buildx version >/dev/null 2>&1; then
     docker buildx build \
       --load \

--- a/scripts/dev-env/docker-build-cache-test.sh
+++ b/scripts/dev-env/docker-build-cache-test.sh
@@ -11,6 +11,9 @@ docker() {
   if [ "${1:-} ${2:-}" = "buildx version" ]; then
     return "${MOCK_BUILDX_VERSION_STATUS:-0}"
   fi
+  if [ "${1:-} ${2:-}" = "image inspect" ] && [ "${MOCK_IMAGE_INSPECT_STATUS:-0}" != "0" ]; then
+    return "${MOCK_IMAGE_INSPECT_STATUS}"
+  fi
   printf '%s\n' "$*" >> "${calls_file}"
 }
 
@@ -65,5 +68,25 @@ if output="$(AXERN_DOCKER_CACHE_BACKEND=registry \
   exit 1
 fi
 grep -Fq "AXERN_DOCKER_CACHE_BACKEND must be none or gha" <<< "${output}"
+
+: > "${calls_file}"
+source "${AXERN_ROOT}/runtime/axnoded/scripts/lib/verify-docker-common.sh"
+VERIFY_DOCKER_VARIANT=full
+VERIFY_DOCKER_PLATFORM=linux/amd64
+NODE_RUNTIME_BASE_IMAGE_TAG=axern/local-node-runtime-base:dev
+build_verify_image archive crates-io
+assert_contains "image inspect axern/local-node-runtime-base:dev"
+assert_contains "build --platform linux/amd64 -f"
+if grep -Fq "buildx build" "${calls_file}"; then
+  echo "local-parent build unexpectedly used an isolated Buildx image store" >&2
+  exit 1
+fi
+
+if output="$(MOCK_IMAGE_INSPECT_STATUS=1 \
+  axern_docker_build_from_local_parent missing-parent:dev -t child:dev . 2>&1)"; then
+  echo "local-parent build unexpectedly accepted a missing parent" >&2
+  exit 1
+fi
+grep -Fq "required local parent image is not loaded: missing-parent:dev" <<< "${output}"
 
 echo "docker_build_cache_test_ok=true"

--- a/scripts/dev-env/docker-build-cache.sh
+++ b/scripts/dev-env/docker-build-cache.sh
@@ -78,3 +78,18 @@ axern_docker_build() {
 
   DOCKER_BUILDKIT="${DOCKER_BUILDKIT:-1}" docker build "${args[@]}"
 }
+
+# A docker-container Buildx builder has its own image store. Use the daemon
+# builder when a later image consumes a parent that an earlier --load exported
+# into the local Docker image store.
+axern_docker_build_from_local_parent() {
+  local parent_image="$1"
+  shift
+
+  if ! docker image inspect "${parent_image}" >/dev/null 2>&1; then
+    echo "required local parent image is not loaded: ${parent_image}" >&2
+    return 1
+  fi
+
+  DOCKER_BUILDKIT="${DOCKER_BUILDKIT:-1}" docker build "$@"
+}


### PR DESCRIPTION
## Summary
- route full verify-image builds through the Docker daemon builder that owns the loaded node runtime base
- fail clearly when the required local parent image is missing
- cover the full verify-image routing and isolated-Buildx regression in the Docker cache contract test

## Root cause
The GHA-cached base build runs in a `docker-container` Buildx builder and exports with `--load` into the daemon image store. Reusing the isolated builder for the child image cannot resolve that local tag and incorrectly attempts a Docker Hub pull.

## Validation
- `bash -n scripts/dev-env/docker-build-cache.sh runtime/axnoded/scripts/lib/verify-docker-common.sh scripts/dev-env/docker-build-cache-test.sh`
- `shellcheck scripts/dev-env/docker-build-cache.sh runtime/axnoded/scripts/lib/verify-docker-common.sh scripts/dev-env/docker-build-cache-test.sh`
- `bash scripts/dev-env/docker-build-cache-test.sh`
- `bash scripts/release/image-build-contract-check.sh`
- `make verify-changed-plan`
- `make verify-changed`
- `make release-check`