### PR TITLE
fix(ci): route CLI E2E node to host control plane

### DIFF
--- a/mk/root.mk
+++ b/mk/root.mk
@@ -1,7 +1,7 @@
 .PHONY: bootstrap bootstrap-tools \
 		bootstrap-go bootstrap-rust bootstrap-ts bootstrap-py \
 		build test lint fmt clean protos proto-generate proto-generated-check agent-doc-check open-source-check release-check release-build verification-plan-contract post-merge-workflow-contract verify-changed verify-changed-plan verify-fast-all verify-full verify-release axern-cli-build axern-cli-install axrun-build axrun-install axern-cli-check-architecture axern-cli-dashboard-smoke gatewayd-check-architecture imagemgr-check-architecture axern-cli-e2e axern-cli-image-ref-e2e bpfnetctl-build \
-		hermetic-dns-contract-check \
+		hermetic-dns-contract-check cli-e2e-environment-contract \
 		gateway-dashboard-assets grafana-assets-check \
 		build-go test-go lint-go fmt-go \
 		build-rust test-rust lint-rust fmt-rust \
@@ -99,6 +99,7 @@ release-check: ## Verify release versions and package contracts
 	bash $(ROOTDIR)/scripts/release/helm-platform-contract-check.sh
 	bash $(ROOTDIR)/scripts/release/homebrew-formula-check.sh
 	bash $(ROOTDIR)/scripts/dev-env/docker-build-cache-test.sh
+	$(MAKE) cli-e2e-environment-contract
 	bash $(ROOTDIR)/scripts/release/image-build-contract-check.sh
 	bash $(ROOTDIR)/scripts/proxy-env-contract-check.sh
 	bash $(ROOTDIR)/scripts/dev-env/hermetic-dns-contract-check.sh
@@ -115,6 +116,9 @@ post-merge-workflow-contract: ## Verify unattended post-merge regression workflo
 
 hermetic-dns-contract-check: ## Verify local verification uses only the repository DNS fixture
 	bash $(ROOTDIR)/scripts/dev-env/hermetic-dns-contract-check.sh
+
+cli-e2e-environment-contract: ## Verify the CLI E2E node can route to host control-plane services
+	bash $(ROOTDIR)/scripts/cli-e2e/environment-contract-test.sh
 
 release-build: release-check ## Build CLI archives and the Helm package
 	bash $(ROOTDIR)/scripts/release/build-cli.sh

--- a/scripts/cli-e2e/environment-contract-test.sh
+++ b/scripts/cli-e2e/environment-contract-test.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+AXERN_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+python3 - "${AXERN_ROOT}/scripts/cli-e2e/environment.sh" <<'PY'
+import pathlib
+import sys
+
+environment = pathlib.Path(sys.argv[1]).read_text()
+start = environment.index('docker run -d \\\n    --name "${NODE_CONTAINER_NAME}"')
+end = environment.index('    "${IMAGE_TAG}" \\\n', start)
+node_run = environment[start:end]
+
+for required in (
+    '--add-host "host.docker.internal:host-gateway"',
+    '-e "AXNODED_CONTROL_PLANE_TARGET=host.docker.internal:${CONTROLD_GRPC_ADDRESS##*:}"',
+):
+    if required not in node_run:
+        raise SystemExit(f"CLI E2E node container is missing host control-plane routing: {required}")
+
+if '-grpc-address "0.0.0.0:${CONTROLD_GRPC_ADDRESS##*:}"' not in environment:
+    raise SystemExit("CLI E2E controld must listen beyond host loopback for the node container")
+PY
+
+echo "cli_e2e_environment_contract_ok=true"

--- a/scripts/cli-e2e/environment.sh
+++ b/scripts/cli-e2e/environment.sh
@@ -175,6 +175,7 @@ setup_e2e_environment() {
     --name "${NODE_CONTAINER_NAME}" \
     --privileged \
     --platform "${VERIFY_DOCKER_PLATFORM}" \
+    --add-host "host.docker.internal:host-gateway" \
     -p "${NODE_GRPC_ADDRESS}:${NODE_GRPC_ADDRESS##*:}" \
     --volume "${shared_run_dir}:/shared/run" \
     --volume "${cert_dir}:/shared/certs:ro" \


### PR DESCRIPTION
## Summary

- map `host.docker.internal` to Docker's host gateway for the privileged CLI E2E node container
- keep the node reporter and tunnel daemon able to reach the host-bound control plane on native Linux runners
- add a release contract covering the listener, host alias, and control-plane target together

## Evidence

Post-Merge Full run 34586764956 at main SHA `24f66b128a285790eef232157219979a8805d1d2` built and started the node image successfully, but `/nodesz` remained empty while axnoded and node-tunneld repeatedly timed out against `host.docker.internal`. The repository's Compose and other native Linux Docker paths already inject `host.docker.internal:host-gateway`; this standalone `docker run` path did not.

## Validation

- `bash -n scripts/cli-e2e/environment.sh scripts/cli-e2e/environment-contract-test.sh`
- `shellcheck scripts/cli-e2e/environment-contract-test.sh`
- `make cli-e2e-environment-contract`
- `make release-check`
- `make verify-changed-plan`
- `make verify-changed`
- `git diff --check`
