### PR TITLE
fix(ci): isolate Docker E2E network routes

### DIFF
--- a/runtime/axnoded/Makefile
+++ b/runtime/axnoded/Makefile
@@ -49,6 +49,8 @@ HOST_TEST_PACKAGES ?= ./cmd/axern-sandboxd/... ./config ./internal/demo/nginx ./
 	verify-sandboxd-provider-smoke \
 	verify-sandboxd-provider-e2e \
 	verify-sandboxd-packaging \
+	verify-docker-network-contract \
+	verify-startup-matrix-contract \
 	verify-sandboxd-release-readiness \
 	verify-node-cli-e2e \
 	verify-node-inventory-e2e \
@@ -111,7 +113,7 @@ else
 	@exit 1
 endif
 
-test: ## run the full Linux test suite
+test: verify-docker-network-contract verify-startup-matrix-contract ## run the full Linux test suite
 	@echo "$(WHALE) $@"
 ifneq ($(GOOS),linux)
 	@echo "make test is Linux-only (current GOOS=$(GOOS)); use 'make test-host' locally or run inside the Linux devbox / verify container." >&2
@@ -120,13 +122,19 @@ endif
 	@$(GO) clean -testcache
 	@$(GOTEST) ${TESTFLAGS} ${PACKAGES}
 
-test-host: ## run the host-safe unit subset for non-Linux development hosts
+test-host: verify-docker-network-contract verify-startup-matrix-contract ## run the host-safe unit subset for non-Linux development hosts
 	@echo "$(WHALE) $@"
 	@$(GO) clean -testcache
 	@$(GOTEST) ${TESTFLAGS} ${HOST_TEST_PACKAGES}
 
 check-architecture: ## verify axnoded package boundary expectations
 	@bash $(REPO_ROOT)/scripts/axnoded-architecture-check.sh
+
+verify-docker-network-contract: ## verify Docker node harnesses isolate sandbox and host routes
+	@bash ./scripts/verify/docker-network-contract-test.sh
+
+verify-startup-matrix-contract: ## verify startup matrix smoke preserves its persisted report
+	@bash ./scripts/verify/startup-matrix-contract-test.sh
 
 bin/protoc-gen-go-fieldpath: cmd/protoc-gen-go-fieldpath FORCE
 	@echo "$(WHALE) $@"

--- a/runtime/axnoded/scripts/demo/run-dashboard-nginx-demo-in-container.sh
+++ b/runtime/axnoded/scripts/demo/run-dashboard-nginx-demo-in-container.sh
@@ -5,6 +5,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "${ROOT_DIR}"
 . "${ROOT_DIR}/scripts/lib/node-runtime-services.sh"
 NAT_BACKEND="${NAT_BACKEND:-iptables}"
+AXNODED_NETWORK_IP_RANGE="${AXNODED_NETWORK_IP_RANGE:-172.31.0.1/16}"
 VOLUMED_LOG="${VOLUMED_LOG:-/tmp/volumed-dashboard.log}"
 VERIFY_NGINX_ROOTFS_IMAGE="${VERIFY_NGINX_ROOTFS_IMAGE:-/var/lib/axnoded/verify-dashboard-nginx-rootfs.ext4}"
 setup_node_runtime_volume_defaults
@@ -26,7 +27,7 @@ rootDir = "/var/lib/axnoded/root"
 storeDir = "/var/lib/axnoded/store"
 
 [plugin.network]
-ip_range = "172.17.0.1/16"
+ip_range = "${AXNODED_NETWORK_IP_RANGE}"
 nat_backend = "${NAT_BACKEND}"
 
 [plugin.network.ebpf]

--- a/runtime/axnoded/scripts/demo/run-dashboard-nginx-demo.sh
+++ b/runtime/axnoded/scripts/demo/run-dashboard-nginx-demo.sh
@@ -88,6 +88,7 @@ docker run -d \
   --privileged \
   --platform "${VERIFY_DOCKER_PLATFORM}" \
   -e "NAT_BACKEND=${NAT_BACKEND}" \
+  -e AXNODED_NETWORK_IP_RANGE \
   -p "${DASHBOARD_HOST_PORT}:${CONTAINER_HTTP_PORT}" \
   -p "${RUNSC_HOST_PORT}:${RUNSC_HOST_PORT}" \
   -p "${RUNC_HOST_PORT}:${RUNC_HOST_PORT}" \

--- a/runtime/axnoded/scripts/lib/verify-docker-common.sh
+++ b/runtime/axnoded/scripts/lib/verify-docker-common.sh
@@ -453,7 +453,9 @@ prepare_oci_test_image_source() {
 prepare_nydus_test_image_source() {
   local image_ref="$1"
   local source_mode="${NYDUS_TEST_IMAGE_SOURCE:-local-build}"
-  local build_output runtime_ref
+  local local_registry_port="${OCI_TEST_LOCAL_REGISTRY_PORT:-${LOCAL_REGISTRY_PORT:-5001}}"
+  local local_registry_name="${LOCAL_REGISTRY_NAME:-axern-registry}"
+  local build_output registry_ip registry_runtime_host runtime_ref
 
   PREPARED_NYDUS_TEST_IMAGE="${image_ref}"
   OCI_TEST_INSECURE_REGISTRIES="${IMAGEMGR_INSECURE_REGISTRIES:-${OCI_TEST_INSECURE_REGISTRIES:-}}"
@@ -465,7 +467,22 @@ prepare_nydus_test_image_source() {
       return 0
       ;;
     local-build)
-      build_output="$(NYDUS_PLATFORM="${VERIFY_DOCKER_PLATFORM}" bash "${REPO_ROOT}/scripts/dev-env/registry-nydus-image-build.sh")"
+      if ! LOCAL_REGISTRY_PORT="${local_registry_port}" "${REPO_ROOT}/scripts/dev-env/registry-up.sh" >/dev/null; then
+        echo "failed to start the repo-managed local registry on port ${local_registry_port}" >&2
+        return 1
+      fi
+      registry_ip="$(docker inspect --format '{{with index .NetworkSettings.Networks "bridge"}}{{.IPAddress}}{{end}}' "${local_registry_name}")"
+      if [ -z "${registry_ip}" ]; then
+        echo "local registry has no bridge address: ${local_registry_name}" >&2
+        return 1
+      fi
+      registry_runtime_host="${registry_ip}:5000"
+      build_output="$(
+        LOCAL_REGISTRY_PORT="${local_registry_port}" \
+          LOCAL_REGISTRY_CLUSTER_HOST="${registry_runtime_host}" \
+          NYDUS_PLATFORM="${VERIFY_DOCKER_PLATFORM}" \
+          bash "${REPO_ROOT}/scripts/dev-env/registry-nydus-image-build.sh"
+      )"
       runtime_ref="$(printf '%s\n' "${build_output}" | awk -F= '$1 == "cluster_nydus_image" {print $2}')"
       if [ -z "${runtime_ref}" ]; then
         printf '%s\n' "${build_output}" >&2
@@ -484,6 +501,10 @@ prepare_nydus_test_image_source() {
   else
     OCI_TEST_INSECURE_REGISTRIES="${runtime_ref%%/*}"
   fi
+  case ",${REGISTRY_NO_PROXY}," in
+    *,"${registry_ip}",*) ;;
+    *) REGISTRY_NO_PROXY="${REGISTRY_NO_PROXY:+${REGISTRY_NO_PROXY},}${registry_ip}" ;;
+  esac
 
   PREPARED_NYDUS_TEST_IMAGE="${runtime_ref}"
   export PREPARED_NYDUS_TEST_IMAGE OCI_TEST_INSECURE_REGISTRIES REGISTRY_NO_PROXY

--- a/runtime/axnoded/scripts/verify/docker-network-contract-test.sh
+++ b/runtime/axnoded/scripts/verify/docker-network-contract-test.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+AXNODED_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+python3 - \
+  "${AXNODED_DIR}/scripts/demo/run-dashboard-nginx-demo-in-container.sh" \
+  "${AXNODED_DIR}/scripts/demo/run-dashboard-nginx-demo.sh" \
+  "${AXNODED_DIR}/scripts/verify/verify-bpfnetctl-e2e.sh" \
+  "${AXNODED_DIR}/scripts/verify/node-all-in-one-entrypoint.sh" \
+  "${AXNODED_DIR}/scripts/verify/verify-node-python-runtime-e2e.sh" \
+  "${AXNODED_DIR}/scripts/verify/verify-node-service-probes-e2e.sh" \
+  "${AXNODED_DIR}/scripts/verify/verify-node-service-volumes-e2e.sh" <<'PY'
+import ipaddress
+import pathlib
+import re
+import sys
+
+docker_bridge = ipaddress.ip_network("172.17.0.0/16")
+
+
+def assert_isolated_default(path):
+    text = path.read_text()
+    node_range = re.search(
+        r'^(?:export )?AXNODED_NETWORK_IP_RANGE="\$\{AXNODED_NETWORK_IP_RANGE:-([^}]+)\}"$',
+        text,
+        re.MULTILINE,
+    )
+    if node_range is None:
+        raise SystemExit(f"{path.name} must define an overridable node sandbox network range")
+    if ipaddress.ip_interface(node_range.group(1)).network.overlaps(docker_bridge):
+        raise SystemExit(f"{path.name} node sandbox network must not overlap Docker's default bridge")
+
+
+dashboard_inner = pathlib.Path(sys.argv[1])
+assert_isolated_default(dashboard_inner)
+if 'ip_range = "${AXNODED_NETWORK_IP_RANGE}"' not in dashboard_inner.read_text():
+    raise SystemExit("dashboard axnoded config must use AXNODED_NETWORK_IP_RANGE")
+
+for path in map(pathlib.Path, sys.argv[2:4]):
+    if '-e AXNODED_NETWORK_IP_RANGE' not in path.read_text():
+        raise SystemExit(f"{path.name} must pass the dashboard node network override")
+
+assert_isolated_default(pathlib.Path(sys.argv[4]))
+
+python_runtime = pathlib.Path(sys.argv[5])
+python_runtime_text = python_runtime.read_text()
+for fragment in (
+    '--network "${POSTGRES_NETWORK_NAME}"',
+    'AXNODED_CONTROL_PLANE_TARGET=controld:${CONTROLD_GRPC_PORT}',
+    'AXNODED_CONTROL_PLANE_NODE_TARGET=${NODE_CONTAINER_NAME}:${NODE_GRPC_PORT}',
+):
+    if fragment not in python_runtime_text:
+        raise SystemExit(f"{python_runtime.name} must use its shared Docker network: {fragment}")
+
+for path in map(pathlib.Path, sys.argv[6:]):
+    text = path.read_text()
+    if '--add-host "host.docker.internal:host-gateway"' not in text:
+        raise SystemExit(f"{path.name} must map the Linux host gateway for its control plane")
+    if '-grpc-address "0.0.0.0:' not in text:
+        raise SystemExit(f"{path.name} must expose controld on the Linux host gateway")
+PY
+
+echo "docker_network_contract_ok=true"

--- a/runtime/axnoded/scripts/verify/docker-network-contract-test.sh
+++ b/runtime/axnoded/scripts/verify/docker-network-contract-test.sh
@@ -10,7 +10,8 @@ python3 - \
   "${AXNODED_DIR}/scripts/verify/node-all-in-one-entrypoint.sh" \
   "${AXNODED_DIR}/scripts/verify/verify-node-python-runtime-e2e.sh" \
   "${AXNODED_DIR}/scripts/verify/verify-node-service-probes-e2e.sh" \
-  "${AXNODED_DIR}/scripts/verify/verify-node-service-volumes-e2e.sh" <<'PY'
+  "${AXNODED_DIR}/scripts/verify/verify-node-service-volumes-e2e.sh" \
+  "${AXNODED_DIR}/scripts/lib/verify-docker-common.sh" <<'PY'
 import ipaddress
 import pathlib
 import re
@@ -53,12 +54,24 @@ for fragment in (
     if fragment not in python_runtime_text:
         raise SystemExit(f"{python_runtime.name} must use its shared Docker network: {fragment}")
 
-for path in map(pathlib.Path, sys.argv[6:]):
+for path in map(pathlib.Path, sys.argv[6:8]):
     text = path.read_text()
     if '--add-host "host.docker.internal:host-gateway"' not in text:
         raise SystemExit(f"{path.name} must map the Linux host gateway for its control plane")
     if '-grpc-address "0.0.0.0:' not in text:
         raise SystemExit(f"{path.name} must expose controld on the Linux host gateway")
+
+docker_common = pathlib.Path(sys.argv[8]).read_text()
+for fragment in (
+    'registry_runtime_host="${registry_ip}:5000"',
+    'LOCAL_REGISTRY_CLUSTER_HOST="${registry_runtime_host}"',
+    'REGISTRY_NO_PROXY="${REGISTRY_NO_PROXY:+${REGISTRY_NO_PROXY},}${registry_ip}"',
+):
+    if fragment not in docker_common:
+        raise SystemExit(
+            "Nydus local-build verification must use the registry container bridge endpoint: "
+            + fragment
+        )
 PY
 
 echo "docker_network_contract_ok=true"

--- a/runtime/axnoded/scripts/verify/node-all-in-one-entrypoint.sh
+++ b/runtime/axnoded/scripts/verify/node-all-in-one-entrypoint.sh
@@ -2,6 +2,9 @@
 set -euo pipefail
 
 export AXNODED_CONTROL_PLANE_NODE_ID="${AXNODED_CONTROL_PLANE_NODE_ID:-node-verify}"
+# Verification runs inside Docker's network namespace. Keep the nested sandbox
+# bridge off Docker's default 172.17.0.0/16 bridge so host and peer routes work.
+export AXNODED_NETWORK_IP_RANGE="${AXNODED_NETWORK_IP_RANGE:-172.31.0.1/16}"
 
 VERIFY_ROOTFS_IMAGE="${VERIFY_ROOTFS_IMAGE:-/var/lib/axnoded/verify-rootfs.ext4}"
 VERIFY_NGINX_ROOTFS_IMAGE="${VERIFY_NGINX_ROOTFS_IMAGE:-/var/lib/axnoded/verify-nginx-rootfs.ext4}"

--- a/runtime/axnoded/scripts/verify/startup-matrix-contract-test.sh
+++ b/runtime/axnoded/scripts/verify/startup-matrix-contract-test.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+AXNODED_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+python3 - "${AXNODED_DIR}/scripts/verify/verify-node-startup-matrix-smoke.sh" <<'PY'
+import pathlib
+import sys
+
+smoke = pathlib.Path(sys.argv[1]).read_text()
+
+required = (
+    'bash "${ROOT_DIR}/scripts/benchmark/startup-matrix-docker.sh" >/dev/null',
+    'matrix_json="$(cat "${output_dir}/matrix.json")"',
+)
+for fragment in required:
+    if fragment not in smoke:
+        raise SystemExit(f"startup matrix smoke is missing output isolation contract: {fragment}")
+
+if 'startup-matrix-docker.sh" > "${output_dir}/matrix.json"' in smoke:
+    raise SystemExit("startup matrix smoke must not redirect stdout over the persisted matrix report")
+PY
+
+echo "startup_matrix_contract_ok=true"

--- a/runtime/axnoded/scripts/verify/verify-bpfnetctl-e2e.sh
+++ b/runtime/axnoded/scripts/verify/verify-bpfnetctl-e2e.sh
@@ -189,6 +189,7 @@ docker run -d \
   --privileged \
   --platform "${VERIFY_DOCKER_PLATFORM}" \
   -e "NAT_BACKEND=${NAT_BACKEND}" \
+  -e AXNODED_NETWORK_IP_RANGE \
   -p "${DASHBOARD_HOST}:${DASHBOARD_HOST_PORT}:${CONTAINER_HTTP_PORT}" \
   -p "127.0.0.1:${RUNSC_HOST_PORT}:${RUNSC_HOST_PORT}" \
   -p "127.0.0.1:${RUNC_HOST_PORT}:${RUNC_HOST_PORT}" \

--- a/runtime/axnoded/scripts/verify/verify-node-python-runtime-e2e.sh
+++ b/runtime/axnoded/scripts/verify/verify-node-python-runtime-e2e.sh
@@ -238,6 +238,8 @@ docker run -d \
   --name "${NODE_CONTAINER_NAME}" \
   --privileged \
   --platform "${VERIFY_DOCKER_PLATFORM}" \
+  --network "${POSTGRES_NETWORK_NAME}" \
+  --add-host "host.docker.internal:host-gateway" \
   -p "${NODE_GRPC_HOST}:${NODE_GRPC_PORT}:${NODE_GRPC_PORT}" \
   --volume "${shared_run_dir}:/shared/run" \
   --volume "${cert_dir}:/shared/certs:ro" \
@@ -246,10 +248,10 @@ docker run -d \
   -e "REGISTRY_PROXY_URL=${REGISTRY_PROXY_URL}" \
   -e "REGISTRY_NO_PROXY=${REGISTRY_NO_PROXY}" \
   -e "AXNODED_HTTP_ADDRESS=${AXNODED_HTTP_ADDRESS}" \
-  -e "AXNODED_CONTROL_PLANE_TARGET=host.docker.internal:${CONTROLD_GRPC_PORT}" \
+  -e "AXNODED_CONTROL_PLANE_TARGET=controld:${CONTROLD_GRPC_PORT}" \
   -e "AXNODED_CONTROL_PLANE_NODE_ID=${CONTROL_PLANE_NODE_ID}" \
   -e "AXNODED_CONTROL_PLANE_NODE_AUTH_TOKEN=${CONTROL_PLANE_NODE_AUTH_TOKEN}" \
-  -e "AXNODED_CONTROL_PLANE_NODE_TARGET=host.docker.internal:${NODE_GRPC_PORT}" \
+  -e "AXNODED_CONTROL_PLANE_NODE_TARGET=${NODE_CONTAINER_NAME}:${NODE_GRPC_PORT}" \
   -e "AXNODED_CONTROL_PLANE_HEARTBEAT_INTERVAL=1s" \
   -e "AXNODED_CONTROL_PLANE_TLS_CA_CERT=/shared/certs/ca.crt" \
   -e "AXNODED_CONTROL_PLANE_TLS_CERT=/shared/certs/node.crt" \

--- a/runtime/axnoded/scripts/verify/verify-node-retention-e2e-in-container.sh
+++ b/runtime/axnoded/scripts/verify/verify-node-retention-e2e-in-container.sh
@@ -148,14 +148,19 @@ wait_for_jq \
   30 \
   'any(.mounts[]?; .image_url == $image_url)' \
   --arg image_url "${IMAGE_URL}"
+locality_key="$(jq -er \
+  --arg image_url "${IMAGE_URL}" \
+  '.mounts[] | select(.image_url == $image_url) | "image:" + (if .cache_key == null or .cache_key == "" then .image_url else .cache_key end)' \
+  "${details_file}")"
 
 fetch_axnoded_inventory "${inventory_file}"
 wait_for_jq \
   "inventory retained counts after first delete" \
   "${inventory_file}" \
   30 \
-  '.heat.retained_runtime_count == 1 and .heat.retained_rootfs_count == 1 and .components.imagemgr.mounted_image_count >= 1 and (.heat.mounted_image_urls | index($image_url) != null) and any(.heat.locality[]?; .key == ("image:" + $image_url) and .retained_runtime_count >= 1 and .retained_rootfs_count >= 1 and .mounted == true)' \
-  --arg image_url "${IMAGE_URL}"
+  '.heat.retained_runtime_count == 1 and .heat.retained_rootfs_count == 1 and .components.imagemgr.mounted_image_count >= 1 and (.heat.mounted_image_urls | index($image_url) != null) and any(.heat.locality[]?; .key == $locality_key and .retained_runtime_count >= 1 and .retained_rootfs_count >= 1 and .mounted == true)' \
+  --arg image_url "${IMAGE_URL}" \
+  --arg locality_key "${locality_key}"
 
 container_id="$(start_container "${runtime_name}" "${runtime_id}" "/tmp/${runtime_name}.retention.second.stdout" "/tmp/${runtime_name}.retention.second.stderr")"
 [ -n "${container_id}" ] || {
@@ -170,8 +175,8 @@ wait_for_jq \
   "inventory retained counts after second delete" \
   "${inventory_file}" \
   30 \
-  '.heat.retained_runtime_count == 1 and .heat.retained_rootfs_count == 1 and any(.heat.locality[]?; .key == ("image:" + $image_url) and .retained_runtime_count >= 1 and .retained_rootfs_count >= 1)' \
-  --arg image_url "${IMAGE_URL}"
+  '.heat.retained_runtime_count == 1 and .heat.retained_rootfs_count == 1 and any(.heat.locality[]?; .key == $locality_key and .retained_runtime_count >= 1 and .retained_rootfs_count >= 1)' \
+  --arg locality_key "${locality_key}"
 
 metrics_output="$(fetch_metrics)"
 metricsz_assert_delta "${metrics_before}" "${metrics_output}" "axern.axnoded_startup_total" "counter" "1" \
@@ -187,8 +192,9 @@ wait_for_jq \
   "inventory to drop retained runtime after ttl" \
   "${inventory_file}" \
   "$((ttl_seconds + 10))" \
-  '.heat.retained_runtime_count == 0 and .heat.retained_rootfs_count == 0 and .components.imagemgr.mounted_image_count == 0 and (.heat.mounted_image_urls | index($image_url) == null) and all(.heat.locality[]?; .key != ("image:" + $image_url) or (.retained_runtime_count == 0 and .retained_rootfs_count == 0))' \
-  --arg image_url "${IMAGE_URL}"
+  '.heat.retained_runtime_count == 0 and .heat.retained_rootfs_count == 0 and .components.imagemgr.mounted_image_count == 0 and (.heat.mounted_image_urls | index($image_url) == null) and all(.heat.locality[]?; .key != $locality_key or (.retained_runtime_count == 0 and .retained_rootfs_count == 0))' \
+  --arg image_url "${IMAGE_URL}" \
+  --arg locality_key "${locality_key}"
 
 fetch_imagemgr_details "${details_file}"
 wait_for_jq \

--- a/runtime/axnoded/scripts/verify/verify-node-service-probes-e2e.sh
+++ b/runtime/axnoded/scripts/verify/verify-node-service-probes-e2e.sh
@@ -231,7 +231,7 @@ fi
 
 AXERN_RUNTIME_CATALOG_PYTHON311_IMAGE="${PYTHON_RUNTIME_IMAGE_REF}" \
   "${CONTROLD_BIN}" \
-  -grpc-address "${CONTROLD_GRPC_ADDRESS}" \
+  -grpc-address "0.0.0.0:${CONTROLD_GRPC_ADDRESS##*:}" \
   -http-address "${CONTROLD_HTTP_ADDRESS}" \
   -tls-ca-cert "${cert_dir}/ca.crt" \
   -tls-cert "${cert_dir}/controld.crt" \
@@ -271,6 +271,7 @@ docker run -d \
   --name "${NODE_CONTAINER_NAME}" \
   --privileged \
   --platform "${VERIFY_DOCKER_PLATFORM}" \
+  --add-host "host.docker.internal:host-gateway" \
   -p "${NODE_GRPC_ADDRESS}:${NODE_GRPC_ADDRESS##*:}" \
   --volume "${shared_run_dir}:/shared/run" \
   --volume "${cert_dir}:/shared/certs:ro" \

--- a/runtime/axnoded/scripts/verify/verify-node-service-volumes-e2e.sh
+++ b/runtime/axnoded/scripts/verify/verify-node-service-volumes-e2e.sh
@@ -234,7 +234,7 @@ fi
 
 AXERN_RUNTIME_CATALOG_PYTHON311_IMAGE="${PYTHON_RUNTIME_IMAGE_REF}" \
   "${CONTROLD_BIN}" \
-  -grpc-address "${CONTROLD_GRPC_ADDRESS}" \
+  -grpc-address "0.0.0.0:${CONTROLD_GRPC_ADDRESS##*:}" \
   -http-address "${CONTROLD_HTTP_ADDRESS}" \
   -tls-ca-cert "${cert_dir}/ca.crt" \
   -tls-cert "${cert_dir}/controld.crt" \
@@ -274,6 +274,7 @@ docker run -d \
   --name "${NODE_CONTAINER_NAME}" \
   --privileged \
   --platform "${VERIFY_DOCKER_PLATFORM}" \
+  --add-host "host.docker.internal:host-gateway" \
   -p "${NODE_GRPC_ADDRESS}:${NODE_GRPC_ADDRESS##*:}" \
   --volume "${shared_run_dir}:/shared/run" \
   --volume "${cert_dir}:/shared/certs:ro" \

--- a/runtime/axnoded/scripts/verify/verify-node-startup-matrix-smoke.sh
+++ b/runtime/axnoded/scripts/verify/verify-node-startup-matrix-smoke.sh
@@ -13,7 +13,7 @@ STARTUP_MATRIX_OUTPUT_DIR="${output_dir}" \
 STARTUP_MATRIX_SCENARIOS="runsc-local,runc-local" \
 STARTUP_MATRIX_COLD_SAMPLES=1 \
 STARTUP_MATRIX_WARM_SAMPLES=2 \
-bash "${ROOT_DIR}/scripts/benchmark/startup-matrix-docker.sh" > "${output_dir}/matrix.json"
+bash "${ROOT_DIR}/scripts/benchmark/startup-matrix-docker.sh" >/dev/null
 
 matrix_json="$(cat "${output_dir}/matrix.json")"
 scenario_report="${output_dir}/scenarios/runsc-local.json"

--- a/runtime/imagemgr/api/inventory_locality.go
+++ b/runtime/imagemgr/api/inventory_locality.go
@@ -90,6 +90,9 @@ func (w *HttpWorker) buildLocalityEntries(
 func mountLocalityKey(mount MountedImageDetail) (string, bool) {
 	switch mount.MountType {
 	case MountTypeOCI:
+		if mount.CacheKey != "" {
+			return "image:" + mount.CacheKey, true
+		}
 		if mount.ImageURL == "" {
 			return "", false
 		}

--- a/runtime/imagemgr/api/inventory_locality_test.go
+++ b/runtime/imagemgr/api/inventory_locality_test.go
@@ -1,0 +1,41 @@
+package api
+
+import "testing"
+
+func TestMountLocalityKeyUsesResolvedOCIIdentity(t *testing.T) {
+	tests := []struct {
+		name  string
+		mount MountedImageDetail
+		want  string
+	}{
+		{
+			name: "resolved cache identity",
+			mount: MountedImageDetail{
+				ImageURL:  "docker.io/library/busybox@sha256:source",
+				CacheKey:  "index.docker.io/library/busybox@sha256:resolved",
+				MountType: MountTypeOCI,
+			},
+			want: "image:index.docker.io/library/busybox@sha256:resolved",
+		},
+		{
+			name: "legacy image URL fallback",
+			mount: MountedImageDetail{
+				ImageURL:  "docker.io/library/busybox@sha256:source",
+				MountType: MountTypeOCI,
+			},
+			want: "image:docker.io/library/busybox@sha256:source",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := mountLocalityKey(tt.mount)
+			if !ok {
+				t.Fatal("mountLocalityKey() ok = false, want true")
+			}
+			if got != tt.want {
+				t.Fatalf("mountLocalityKey() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/scripts/cli-e2e/environment-contract-test.sh
+++ b/scripts/cli-e2e/environment-contract-test.sh
@@ -3,17 +3,23 @@ set -euo pipefail
 
 AXERN_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
-python3 - "${AXERN_ROOT}/scripts/cli-e2e/environment.sh" <<'PY'
+python3 - \
+  "${AXERN_ROOT}/scripts/cli-e2e/environment.sh" \
+  "${AXERN_ROOT}/scripts/cli-e2e/lib.sh" <<'PY'
+import ipaddress
 import pathlib
+import re
 import sys
 
 environment = pathlib.Path(sys.argv[1]).read_text()
+library = pathlib.Path(sys.argv[2]).read_text()
 start = environment.index('docker run -d \\\n    --name "${NODE_CONTAINER_NAME}"')
 end = environment.index('    "${IMAGE_TAG}" \\\n', start)
 node_run = environment[start:end]
 
 for required in (
     '--add-host "host.docker.internal:host-gateway"',
+    '-e "AXNODED_NETWORK_IP_RANGE=${AXNODED_NETWORK_IP_RANGE}"',
     '-e "AXNODED_CONTROL_PLANE_TARGET=host.docker.internal:${CONTROLD_GRPC_ADDRESS##*:}"',
 ):
     if required not in node_run:
@@ -21,6 +27,20 @@ for required in (
 
 if '-grpc-address "0.0.0.0:${CONTROLD_GRPC_ADDRESS##*:}"' not in environment:
     raise SystemExit("CLI E2E controld must listen beyond host loopback for the node container")
+if 'if ! node_control_plane_tcp_ready; then' not in environment:
+    raise SystemExit("CLI E2E must fail fast when the node cannot reach the host control plane")
+
+node_range = re.search(
+    r'^AXNODED_NETWORK_IP_RANGE="\$\{AXNODED_NETWORK_IP_RANGE:-([^}]+)\}"$',
+    library,
+    re.MULTILINE,
+)
+if node_range is None:
+    raise SystemExit("CLI E2E must define an overridable node sandbox network range")
+if ipaddress.ip_interface(node_range.group(1)).network.overlaps(
+    ipaddress.ip_network("172.17.0.0/16")
+):
+    raise SystemExit("CLI E2E node sandbox network must not overlap Docker's default bridge")
 PY
 
 echo "cli_e2e_environment_contract_ok=true"

--- a/scripts/cli-e2e/environment.sh
+++ b/scripts/cli-e2e/environment.sh
@@ -184,6 +184,7 @@ setup_e2e_environment() {
     -e "REGISTRY_PROXY_URL=${REGISTRY_PROXY_URL}" \
     -e "REGISTRY_NO_PROXY=${REGISTRY_NO_PROXY}" \
     -e "AXNODED_HTTP_ADDRESS=${NODE_HTTP_ADDRESS}" \
+    -e "AXNODED_NETWORK_IP_RANGE=${AXNODED_NETWORK_IP_RANGE}" \
     -e "AXNODED_MAX_INSTANCE_NUM=32" \
     -e "AXNODED_INTERFACE_CACHE_SIZE=16" \
     -e "AXNODED_CGROUP_CACHE_SIZE=16" \
@@ -213,6 +214,12 @@ setup_e2e_environment() {
 
   if ! [ -S "${shared_run_dir}/axnoded.sock" ] || ! docker exec "${NODE_CONTAINER_NAME}" /bin/bash -lc "curl -fsS http://127.0.0.1:23001/readyz >/dev/null"; then
     echo "node container did not become ready in time" >&2
+    dump_logs
+    exit 1
+  fi
+
+  if ! node_control_plane_tcp_ready; then
+    echo "node container cannot reach the host control-plane listener" >&2
     dump_logs
     exit 1
   fi

--- a/scripts/cli-e2e/lib.sh
+++ b/scripts/cli-e2e/lib.sh
@@ -14,6 +14,9 @@ GATEWAY_HTTP_ADDRESS="${GATEWAY_HTTP_ADDRESS:-127.0.0.1:25080}"
 GATEWAY_CONTROL_ADDRESS="${GATEWAY_CONTROL_ADDRESS:-127.0.0.1:25000}"
 GATEWAY_SSH_ADDRESS="${GATEWAY_SSH_ADDRESS:-127.0.0.1:25022}"
 AXNODED_SOCKET="${AXNODED_SOCKET:-/shared/run/axnoded.sock}"
+# The privileged node creates sandbox0 from this range. Keep it distinct from
+# Docker's default 172.17.0.0/16 bridge so host-gateway traffic stays on eth0.
+AXNODED_NETWORK_IP_RANGE="${AXNODED_NETWORK_IP_RANGE:-172.31.0.1/16}"
 CONTROL_PLANE_NODE_ID="${CONTROL_PLANE_NODE_ID:-node-axern-cli-e2e}"
 CONTROL_PLANE_NODE_AUTH_TOKEN="${CONTROL_PLANE_NODE_AUTH_TOKEN:-node-axern-cli-e2e-token}"
 PYTHON_RUNTIME_IMAGE_REF="${PYTHON_RUNTIME_IMAGE_REF:-axern/python311-runtime:dev}"
@@ -170,6 +173,7 @@ dump_logs() {
   cat "${gatewayd_log}" >&2 || true
   echo "--- node container logs ---" >&2
   docker logs "${NODE_CONTAINER_NAME}" >&2 || true
+  dump_node_control_plane_route
   dump_node_log_tail "axnoded" "/var/log/axnoded/axnoded.log" 160
   dump_node_log_tail "imagemgr" "/var/lib/imagemgr/logs/imagemgr.log" 120
   dump_node_log_tail "node-tunneld" "/var/log/axnoded/node-tunneld.log" 120
@@ -188,6 +192,47 @@ dump_node_log_tail() {
   local lines="$3"
   echo "--- ${label} log tail ---" >&2
   docker exec "${NODE_CONTAINER_NAME}" sh -lc "test -f '${path}' && tail -n '${lines}' '${path}'" >&2 || true
+}
+
+node_control_plane_tcp_ready() {
+  docker exec \
+    -e "AXERN_E2E_CONTROL_PLANE_PORT=${CONTROLD_GRPC_ADDRESS##*:}" \
+    "${NODE_CONTAINER_NAME}" \
+    bash -lc 'timeout 5 bash -lc "exec 3<>/dev/tcp/host.docker.internal/${AXERN_E2E_CONTROL_PLANE_PORT}"' \
+    >/dev/null 2>&1
+}
+
+dump_node_control_plane_route() {
+  echo "--- node to control-plane route ---" >&2
+  docker exec \
+    -e "AXERN_E2E_CONTROL_PLANE_PORT=${CONTROLD_GRPC_ADDRESS##*:}" \
+    "${NODE_CONTAINER_NAME}" \
+    bash -lc '
+      set +e
+      printf "%s\n" "hosts:"
+      getent ahostsv4 host.docker.internal
+      printf "%s\n" "routes:"
+      ip -4 route show
+      if timeout 5 bash -lc "exec 3<>/dev/tcp/host.docker.internal/${AXERN_E2E_CONTROL_PLANE_PORT}"; then
+        printf "%s\n" "control_plane_tcp_ready=true"
+      else
+        printf "control_plane_tcp_ready=false rc=%s\n" "$?"
+      fi
+      if command -v openssl >/dev/null 2>&1; then
+        timeout 10 openssl s_client \
+          -connect "host.docker.internal:${AXERN_E2E_CONTROL_PLANE_PORT}" \
+          -servername host.docker.internal \
+          -CAfile /shared/certs/ca.crt \
+          -cert /shared/certs/node.crt \
+          -key /shared/certs/node.key \
+          -verify_return_error \
+          -verify_hostname host.docker.internal \
+          -brief </dev/null
+        printf "control_plane_tls_probe_rc=%s\n" "$?"
+      else
+        printf "%s\n" "control_plane_tls_probe=openssl-unavailable"
+      fi
+    ' >&2 || true
 }
 
 run_step() {


### PR DESCRIPTION
## Summary

- Keep nested axnoded sandbox networks off Docker's default bridge CIDR.
- Make containerized control-plane and registry dependencies reachable through explicit, isolated routes.
- Preserve locality retention keys and startup-matrix evidence while exercising the corrected topology.

## Design

The node verification harness now defaults its nested sandbox range to `172.31.0.0/16`, uses a shared Docker network where services are peers, and maps the host gateway only for host-owned control-plane listeners. Nydus local-image conversion uses the registry container's bridge endpoint directly, including `NO_PROXY`, so the registry can remain bound to host loopback instead of being exposed on `0.0.0.0`.

Static contract tests lock down these routing choices and the startup-matrix evidence behavior.

## Verification

- `make verify-changed-plan`
- `make verify-changed`
- `bash runtime/axnoded/scripts/verify/docker-network-contract-test.sh`
- devbox-x: `./scripts/axern/run-cn-accelerated.sh --reuse-images axnoded-verify-node-locality-e2e`
- devbox-x result: `verify_node_locality_e2e_ok=true`
- devbox-x result: `verify_node_locality_e2e_host_ok=true`
- GitHub Actions diagnostic: Post-Merge Full run 34619199266 reproduced the pre-fix Nydus registry failure at exact SHA `3557d1aa80805c97954e41721bee6ac7c9985bab`.

## Checklist

- [x] The change is focused and follows the nearest `AGENTS.md` contract.
- [x] Public behavior is unchanged; no operator documentation update is required.
- [x] Contract and privileged E2E coverage exercise routing, startup, retention, and cleanup behavior where relevant.
- [x] Every commit includes a DCO `Signed-off-by` trailer.
