### PR TITLE
fix(axnoded): drain short-lived command output

### DIFF
--- a/runtime/axnoded/internal/sandboxd/proc/command.go
+++ b/runtime/axnoded/internal/sandboxd/proc/command.go
@@ -30,20 +30,30 @@ func RunCommandOutput(ctx context.Context, waiter *Waiter, name string, args []s
 }
 
 func RunStartedCommand(ctx context.Context, cmd *exec.Cmd, waiter *Waiter) ([]byte, error) {
-	stdoutPipe, err := cmd.StdoutPipe()
+	stdoutReader, stdoutWriter, err := os.Pipe()
 	if err != nil {
 		return nil, fmt.Errorf("stdout pipe: %w", err)
 	}
-	stderrPipe, err := cmd.StderrPipe()
+	defer stdoutReader.Close()
+
+	stderrReader, stderrWriter, err := os.Pipe()
 	if err != nil {
+		stdoutWriter.Close()
 		return nil, fmt.Errorf("stderr pipe: %w", err)
 	}
+	defer stderrReader.Close()
+	cmd.Stdout = stdoutWriter
+	cmd.Stderr = stderrWriter
 	if err := cmd.Start(); err != nil {
+		stdoutWriter.Close()
+		stderrWriter.Close()
 		return nil, fmt.Errorf("start %s: %w", cmd.Path, err)
 	}
+	stdoutWriter.Close()
+	stderrWriter.Close()
 
-	stdoutCh := readAll(stdoutPipe)
-	stderrCh := readAll(stderrPipe)
+	stdoutCh := readAll(stdoutReader)
+	stderrCh := readAll(stderrReader)
 	waitCh := waitForCommand(cmd, waiter)
 	var timedOut error
 	var result Result

--- a/runtime/axnoded/internal/sandboxd/proc/command_test.go
+++ b/runtime/axnoded/internal/sandboxd/proc/command_test.go
@@ -20,6 +20,19 @@ func TestRunShellOutputUsesSharedWaiter(t *testing.T) {
 	}
 }
 
+func TestRunShellOutputDrainsShortLivedOutputWithoutWaiter(t *testing.T) {
+	const expected = "1280 720"
+	for i := 0; i < 200; i++ {
+		output, err := RunShellOutput(context.Background(), nil, "printf '1280 720'", nil, time.Second)
+		if err != nil {
+			t.Fatalf("RunShellOutput() iteration %d error = %v", i, err)
+		}
+		if string(output) != expected {
+			t.Fatalf("output iteration %d = %q, want %q", i, output, expected)
+		}
+	}
+}
+
 func TestRunShellOutputHandlesShortLivedNoOutputCommand(t *testing.T) {
 	waiter := NewWaiter(context.Background())
 	defer waiter.Stop()


### PR DESCRIPTION
## Summary

- replace `exec.Cmd.StdoutPipe`/`StderrPipe` with explicitly owned OS pipes in the sandboxd command helper
- keep read ends alive until short-lived command output has been fully drained, independent of `cmd.Wait`
- cover repeated no-waiter commands that emit display geometry and exit immediately

## Root cause

Post-Merge Full run 34626264889, bound to main commit `4d586cd65f0ab329d84ac45b15269118d6e8f8b1`, failed at `[13/33] axnoded-test`. `TestServiceScreenshotWithCommandOverride` observed a successful display command with empty stdout.

`RunStartedCommand` started asynchronous readers from `StdoutPipe` and `StderrPipe` while concurrently calling `cmd.Wait`. Go requires pipe reads to complete before `Wait`; for a very short command, `Wait` could close the pipe before the reader drained it.

## Validation

- `go test ./internal/sandboxd/proc ./internal/sandboxd/computeruse -count=20`
- `go test -race ./internal/sandboxd/proc ./internal/sandboxd/computeruse`
- `make -C runtime/axnoded fmt`
- `make -C runtime/axnoded vet`
- `make verify-changed-plan`
- `make verify-changed`
- repeated target and race tests on `devbox-x`

Native Linux coverage is delegated to the PR CI runner because both local checkouts are Darwin and the local Docker daemon is unavailable.
